### PR TITLE
fix: promise issues

### DIFF
--- a/hooks/useUrlManager.ts
+++ b/hooks/useUrlManager.ts
@@ -50,33 +50,33 @@ export const useUrlManager = () => {
     }
 
     const clearAllFilters = () => {
-        const allKeys = FILTERTAGS.map((key) => {
+        const allKeys = FILTERTAGS.flatMap((key) => {
             if (!urlParams.has(key)) {
                 return []
             }
 
             return urlParams.getAll(key).map((val) => ({ key, filter: val }))
-        }).flat()
+        })
 
         allKeys.map((val) => urlParams.delete(val.key, val.filter))
         router.push(`${pathname}?${urlParams.toString()}`)
     }
 
-    const currentFilterValuesAndKeys = FILTERTAGS.map((key) => {
+    const currentFilterValuesAndKeys = FILTERTAGS.flatMap((key) => {
         if (!urlParams.has(key)) {
             return []
         }
 
         return urlParams.getAll(key).map((val) => ({ key, filter: val }))
-    }).flat()
+    })
 
-    const currentFilterValues = FILTERTAGS.map((key) => {
+    const currentFilterValues = FILTERTAGS.flatMap((key) => {
         if (!urlParams.has(key)) {
             return []
         }
 
         return urlParams.getAll(key)
-    }).flat()
+    })
 
     return {
         addFilterParam,

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,4 +1,4 @@
-import { IssueCardElement } from "../types"
+import type { IssueCardElement } from "../types"
 
 export const SORTOPTIONS = ["sort", "relevance", "newest first", "oldest first"]
 
@@ -21,19 +21,20 @@ export function getValues({
     key: keyof IssueCardElement
     issues: IssueCardElement[]
 }) {
-    let properties: string[] = []
+    const properties = issues.reduce(
+        (acc, issue) => {
+            const project = issue[key]
+            if (Array.isArray(project)) {
+                return acc.concat(project)
+            }
+            acc.push(project as string)
+            return acc
+        },
+        [key] as string[]
+    )
+    const uniqueProperties = Array.from(new Set(properties).values())
 
-    issues.map((project) => {
-        if (Array.isArray(project[key])) {
-            properties.push(...(project[key] as string[]))
-        } else {
-            properties.push(project[key] as string)
-        }
-    })
-
-    properties = Array.from(new Set([key, ...properties]).values())
-
-    return { properties }
+    return { properties: uniqueProperties }
 }
 
 export const createSortKeys = () => {


### PR DESCRIPTION
I noticed an issue with how the promises for fetching and getting a repo issue(s) are constructed. The result are constructed as a side effect inside `Promise.all`, which means we would not really be seeing the benefits of concurrently fetching using `Promise.all`.

I also replaced some array operations that took 2 pass to construct them `.map().flat()` with `.flatMap()`