### PR TITLE
fix: broken links

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { Wrapper } from "@/components/Wrapper"
+import Button from "@/components/button"
 import PageLevel from "@/components/page-level"
 import { curriculums, type KnownCurriculums } from "@/content/curriculums"
 import { slugify } from "@/utils/slugify"
@@ -10,6 +11,29 @@ export default function Curriculum({
     params: { slug: KnownCurriculums }
 }) {
     const curriculum = curriculums[params.slug]
+    if (!curriculum) {
+        return (
+            <section className="flex h-[calc(100vh-250px)] flex-col items-center justify-center">
+                <div className="container mx-auto max-w-md space-y-6 text-center">
+                    <div className="space-y-2">
+                        <h1 className="text-4xl font-bold text-gray-900 sm:text-5xl">
+                            Oops, looks like you&apos;ve taken a wrong turn!
+                        </h1>
+                        <p className="text-gray-900">
+                            The page you&apos;re looking for doesn&apos;t exist
+                            or has been moved.
+                        </p>
+                    </div>
+                    <Button
+                        href="/"
+                        className="w-fit mx-auto text-center py-4 px-8"
+                    >
+                        Go back home
+                    </Button>
+                </div>
+            </section>
+        )
+    }
 
     return (
         <Wrapper>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -27,7 +27,7 @@ export default function Projects() {
                 </div>
                 <div className="flex flex-col gap-y-24 pt-6">
                     <Button
-                        href="/contribute"
+                        href="/good-first-issues"
                         className="w-fit mx-auto text-center py-4 px-8"
                     >
                         Start contributing


### PR DESCRIPTION
This PR fixes two issues;
1. the CTA button link from projects page to good first issues page now has the correct link
2. adds a fallback UI for cases when the slug/params is not present in the `KnownCurriculum` type. This can happen if the user types a wrong url slug in the browser. see screenshot (link https://bitcoindevs.xyz/contribute)
![image](https://github.com/bitcoin-dev-project/bitcoin-dev-project/assets/60826700/a5189f68-82c9-4ee0-8d54-8b4cc9114fd3)
