### PR TITLE
chore: capitalize "Good First Issues" link

### DIFF
--- a/components/page-level.tsx
+++ b/components/page-level.tsx
@@ -108,9 +108,9 @@ export default function PageLevel({
                                     </Link>
                                     <Link
                                         href={`good-first-issues/?repo=${item.repo ?? ""}`}
-                                        className={`w-fit gap-1.5 text-nowrap whitespace-nowrap underline ${item.repo ? "flex" : "hidden"}`}
+                                        className={`w-fit gap-1.5 text-nowrap whitespace-nowrap capitalize underline ${item.repo ? "flex" : "hidden"}`}
                                     >
-                                        Good first Issues
+                                        Good First Issues
                                     </Link>
                                 </div>
                             ) : null}


### PR DESCRIPTION
Update the page-level component to capitalize the "Good First Issues" link. This ensures consistency in the capitalization of the link text.