### PR TITLE
chore: update landing page CTA styles

### DIFF
--- a/components/hero/Hero.tsx
+++ b/components/hero/Hero.tsx
@@ -20,10 +20,10 @@ export function Hero() {
                 <Link href="/bitcoin-core">
                     <button
                         type="button"
-                        className="py-1 pl-4 pr-2 duration-200 border-orange-500 bg-orange-500 hover:text-black h-12 hover:bg-white text-white justify-between border-2 hover:border-white rounded-full inline-flex items-center gap-12"
+                        className="py-1 pl-4 pr-2 duration-200 border-orange-500 bg-orange-500 hover:text-black h-12 hover:bg-white text-white border-[1.5px] hover:border-orange-500 dark:hover:border-white rounded-full inline-flex items-center gap-4 md:gap-12"
                     >
-                        Learn Bitcoin
-                        <div className="bg-black h-8 w-8 text-white inline-flex items-center justify-center rounded-full">
+                        <p className="w-full">Learn Bitcoin</p>
+                        <div className="bg-black h-8 w-12 md:w-14 text-white inline-flex items-center justify-center rounded-full">
                             <span>
                                 <svg
                                     xmlns="http://www.w3.org/2000/svg"
@@ -42,13 +42,13 @@ export function Hero() {
                 <Link href="/good-first-issues">
                     <button
                         type="button"
-                        className="py-1 pl-4 pr-4 duration-200 border-orange-500 bg-transparent text-orange-500 hover:bg-orange-500 hover:text-white h-12 border rounded-full inline-flex items-center justify-center transition-colors duration-200"
+                        className="py-1 pl-4 pr-4 border-orange-500 bg-transparent text-orange-500 hover:bg-orange-500 hover:text-white h-12 border rounded-full inline-flex items-center justify-center transition-colors duration-200"
                     >
                         Contribute to Open Source
                     </button>
                 </Link>
             </div>
-            <div className="max-sm:mt-0 mt-36 lg:mt-44">
+            <div className="max-sm:mt-4 mt-36 lg:mt-44">
                 <p className="font-display text-base text-black-800 dark:text-black-100">
                     Explore products we’ve built to make bitcoin tech more
                     accessible


### PR DESCRIPTION
This PR fixes some CTA style nits I noticed while testing.
1. The spacing between hero CTA button and the text is too small
2. The hover state for the "Learn bitcoin" button in light mode is transparent. I added an orange border to make it visible
3. On mobile, "Learn bitcoin" CTA is vertically aligned when it could be horizontally aligned which is more appealing to the eyes.
4. The border in the Arrow right icon in the "Learn bitcoin" CTA is skewed on Mobile.

**Screenshots:**
*Before:*
<img width="510" alt="Screenshot 2024-07-17 at 12 02 08" src="https://github.com/user-attachments/assets/24cd15ac-519f-4430-8aeb-b2c3a7b26846">
<img width="405" alt="Screenshot 2024-07-17 at 12 01 55" src="https://github.com/user-attachments/assets/b476551a-7f45-41c2-b5f9-cdd99af5b5b3">

*After:*
<img width="406" alt="Screenshot 2024-07-17 at 12 05 40" src="https://github.com/user-attachments/assets/74242f14-3cd4-43df-a5f0-aa2efae04a90">
<img width="523" alt="Screenshot 2024-07-17 at 12 06 22" src="https://github.com/user-attachments/assets/b2973615-2f1d-4a77-a5a4-c1630ccc2330">
