### PR TITLE
Fix compilation errors in script compilation by updating tsconfig.scripts.json

### DIFF
--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -5,7 +5,9 @@
         "outDir": "scripts",
         "strict": true,
         "esModuleInterop": true,
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "skipLibCheck": true
     },
-    "include": ["helpers/**/*.ts", "utils/**/*.ts", "types/**/*.ts"]
+    "include": ["helpers/**/*.ts", "utils/**/*.ts", "types/**/*.ts"],
+    "exclude": ["utils/content-utils.ts"]
 }


### PR DESCRIPTION
This PR addresses compilation errors we have during `npm run compile:scripts`.

### Changes:
- Updated `tsconfig.scripts.json` to include `skipLibCheck`, which skips type checking of declaration files in external libraries (`node_modules`), aligning with our main `tsconfig.json`.
- Excluded `utils/content-utils.ts` from the compilation process to avoid errors related to Contentlayer types that are generated at build time.
