### PR TITLE
Fix/avoid rss folder deletion

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "compile:scripts": "rm -rf scripts && tsc --project tsconfig.scripts.json",
         "fetch-issues": "node scripts/helpers/fetch-issues.js",
         "dev": "next dev",
-        "build": "npm run submodules:update && next build && node ./scripts/rss/postbuild.mjs",
+        "build": "npm run submodules:update && next build && node ./rss/postbuild.mjs",
         "start": "next start",
         "lint": "next lint",
         "submodules:update": "git submodule update --init && git submodule update --remote"

--- a/rss/postbuild.mjs
+++ b/rss/postbuild.mjs
@@ -1,0 +1,7 @@
+import rss from "./rss.mjs"
+
+async function postbuild() {
+    await rss()
+}
+
+postbuild()

--- a/rss/rss.mjs
+++ b/rss/rss.mjs
@@ -1,0 +1,48 @@
+import { writeFileSync, mkdirSync } from "fs"
+import { escape } from "pliny/utils/htmlEscaper.js"
+import siteMetadata from "../data/siteMetadata.js"
+import { allTopics } from "../.contentlayer/generated/index.mjs"
+import { sortPosts } from "pliny/utils/contentlayer.js"
+
+const generateRssItem = (config, post) => `
+  <item>
+    <guid>${config.siteUrl}/topics/${post.slug}</guid>
+    <title>${escape(post.title)}</title>
+    <link>${config.siteUrl}/topics/${post.slug}</link>
+    ${post.summary ? `<description>${escape(post.summary)}</description>` : ""}
+    <pubDate>${new Date(post.date).toUTCString()}</pubDate>
+    <author>${config.author}</author>
+    ${post.tags && post.tags.map((t) => `<category>${t}</category>`).join("")}
+  </item>
+`
+
+const generateRss = (config, posts, page = "feed.xml") => `
+  <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel>
+      <title>${escape(config.title)}</title>
+      <link>${config.siteUrl}/topics</link>
+      <description>${escape(config.description)}</description>
+      <language>${config.language}</language>
+      <managingEditor>${config.author}</managingEditor>
+      <webMaster>${config.author}</webMaster>
+      <lastBuildDate>${new Date(posts[0].date).toUTCString()}</lastBuildDate>
+      <atom:link href="${config.siteUrl}/${page}" rel="self" type="application/rss+xml"/>
+      ${posts.map((post) => generateRssItem(config, post)).join("")}
+    </channel>
+  </rss>
+`
+
+async function generateRSS(config, allTopics, page = "feed.xml") {
+    const publishPosts = allTopics.filter((post) => post.draft !== true)
+    debugger
+    if (publishPosts.length > 0) {
+        const rss = generateRss(config, sortPosts(publishPosts))
+        writeFileSync(`./public/${page}`, rss)
+    }
+}
+
+const rss = () => {
+    generateRSS(siteMetadata, allTopics)
+    console.log("RSS feed generated...")
+}
+export default rss


### PR DESCRIPTION
This PR fixes the issue where the `rss` folder was deleted during the execution of `compile:scripts` command.
By moving `rss` folder outside the script directory we ensure it remains intact