### PR TITLE
feat: fix update issues job

### DIFF
--- a/.github/workflows/update-issues.yaml
+++ b/.github/workflows/update-issues.yaml
@@ -26,6 +26,8 @@ jobs:
               with:
                   persist-credentials: true
                   ref: ${{ matrix.branch }}
+                  fetch-depth: 0
+                  token: ${{ secrets.SFIGS_TOKEN }}
 
             - name: Set up Node.js
               uses: actions/setup-node@v2
@@ -44,8 +46,10 @@ jobs:
               run: npm run fetch-issues
 
             - name: Commit and Push Changes
+              env:
+                  GITHUB_TOKEN: ${{ secrets.SFIGS_TOKEN }}
               run: |
                   git config --global user.email "${{secrets.EMAIL}}"
                   git config --global user.name "${{secrets.NAME}}"
                   git commit -am "chore: update issues" || echo "No changes to commit"
-                  git push
+                  git push origin ${{ matrix.branch }}

--- a/.github/workflows/update-issues.yaml
+++ b/.github/workflows/update-issues.yaml
@@ -6,7 +6,6 @@ on:
     push:
         branches:
             - master
-            - staging
 
 permissions:
     contents: write
@@ -48,4 +47,4 @@ jobs:
                   git config --global user.email "${{secrets.EMAIL}}"
                   git config --global user.name "${{secrets.NAME}}"
                   git add -f public/open-source-projects/issues/
-                  git diff --quiet && git diff --staged --quiet || (git commit -m "Update open source project issues" && git push origin master)
+                  git diff --quiet && git diff --staged --quiet || (git commit -m "Update open source project issues" && git push)

--- a/.github/workflows/update-issues.yaml
+++ b/.github/workflows/update-issues.yaml
@@ -15,17 +15,13 @@ permissions:
 jobs:
     fetch-and-save-issues:
         runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                node-version: [20]
-                branch: [staging, master]
 
         steps:
             - name: Checkout repository
               uses: actions/checkout@v3
               with:
                   persist-credentials: true
-                  ref: ${{ matrix.branch }}
+                  ref: master
                   fetch-depth: 0
                   token: ${{ secrets.SFIGS_TOKEN }}
 
@@ -51,5 +47,5 @@ jobs:
               run: |
                   git config --global user.email "${{secrets.EMAIL}}"
                   git config --global user.name "${{secrets.NAME}}"
-                  git commit -am "chore: update issues" || echo "No changes to commit"
-                  git push origin ${{ matrix.branch }}
+                  git add -f public/open-source-projects/issues/
+                  git diff --quiet && git diff --staged --quiet || (git commit -m "Update open source project issues" && git push origin master)


### PR DESCRIPTION
This pr fixes the failing ci job for updating the good first issues in the public folder. The issue is as a result of the newly updated branch protection rules for the master and staging branches. 
This pr ensures that the github actions uses the SFIGS PAT for pushing refs instead of the default github actions token.