### PR TITLE
Make products logo in the landig page clickable

### DIFF
--- a/components/hero/Hero.tsx
+++ b/components/hero/Hero.tsx
@@ -53,16 +53,16 @@ export function Hero() {
                             role="list"
                             className="flex items-center justify-center gap-10 max-sm:gap-4 mt-8"
                         >
-                            {group.map((company) => (
-                                <li key={company.name} className="flex">
+                            {group.map((product) => (
+                                <li key={product.name} className="flex">
                                     <Link
-                                        href={company.url}
+                                        href={product.url}
                                         target="_blank"
                                         rel="noopener noreferrer"
                                     >
                                         <Image
-                                            src={company.logo}
-                                            alt={company.name}
+                                            src={product.logo}
+                                            alt={product.name}
                                             unoptimized
                                             className="rounded-lg h-16 w-16 max-md:w-12 max-md:h-12 filter grayscale hover:filter-none transition-all duration-300"
                                         />

--- a/components/hero/Hero.tsx
+++ b/components/hero/Hero.tsx
@@ -55,12 +55,18 @@ export function Hero() {
                         >
                             {group.map((company) => (
                                 <li key={company.name} className="flex">
-                                    <Image
-                                        src={company.logo}
-                                        alt={company.name}
-                                        unoptimized
-                                        className="rounded-lg h-16 w-16 max-md:w-12 max-md:h-12 filter grayscale"
-                                    />
+                                    <Link
+                                        href={company.url}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                    >
+                                        <Image
+                                            src={company.logo}
+                                            alt={company.name}
+                                            unoptimized
+                                            className="rounded-lg h-16 w-16 max-md:w-12 max-md:h-12 filter grayscale hover:filter-none transition-all duration-300"
+                                        />
+                                    </Link>
                                 </li>
                             ))}
                         </ul>

--- a/content/landing.tsx
+++ b/content/landing.tsx
@@ -194,16 +194,33 @@ export const values = [
 
 export const hero = [
     [
-        { name: "ChatBTC", logo: logoChatBTC },
-        { name: "Bitcoin Search", logo: logoBitcoinSearch },
+        {
+            name: "ChatBTC",
+            logo: logoChatBTC,
+            url: "https://chat.bitcoinsearch.xyz"
+        },
+        {
+            name: "Bitcoin Search",
+            logo: logoBitcoinSearch,
+            url: "https://bitcoinsearch.xyz"
+        },
         {
             name: "Transcript Review",
             logo: logoTrRev,
-            className: "hidden xl:block"
+            className: "hidden xl:block",
+            url: "https://review.btctranscripts.com"
         },
 
-        { name: "Trsanscript", logo: logoBitcoinTranscript },
-        { name: "Bitcoin TLDR", logo: logoBitcoinTLDR }
+        {
+            name: "Transcript",
+            logo: logoBitcoinTranscript,
+            url: "https://btctranscripts.com"
+        },
+        {
+            name: "Bitcoin TLDR",
+            logo: logoBitcoinTLDR,
+            url: "https://tldr.bitcoinsearch.xyz"
+        }
     ]
 ]
 


### PR DESCRIPTION
This PR updates the Hero section by making product logos clickable, linking to their respective URLs in new tabs. 
Hovering over a logo reveals it's full-color