### PR TITLE
Add missing Setup steps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,31 @@ This is the source code for the [Bitcoin Dev Project](https://bitcoindevs.xyz) t
 
 ## Setup
 
-First, run the development server:
+1) Install the dependencies:
+
+```bash
+npm install
+# or
+yarn install
+# or
+pnpm install
+# or
+bun install
+```
+
+2) Get the `bitcoin-topics` content (initialize the `bitcoin-topics` submodule):
+
+```bash
+npm run submodules:update
+# or
+yarn submodules:update
+# or
+pnpm submodules:update
+# or
+bun submodules:update
+```
+
+3) Run the development server:
 
 ```bash
 npm run dev

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pnpm install
 bun install
 ```
 
-2) Get the `bitcoin-topics` content (initialize the `bitcoin-topics` submodule):
+2) Download submodules:
 
 ```bash
 npm run submodules:update


### PR DESCRIPTION
The current instructions do not sufficiently describe the steps required to get the app up and running locally. 

This changes adds the addition required steps to the README