### PR TITLE
fix: modify the branch name in the workflows

### DIFF
--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -2,7 +2,7 @@ name: Spelling
 
 on:
     pull_request:
-        branches: [main, staging]
+        branches: [master, staging]
 
 jobs:
     spelling:


### PR DESCRIPTION
This PR updates the branch names in the workflows, changing them from `main` to `master`.