### PR TITLE
Fix CORS error for NIP-05 support

### DIFF
--- a/app/.well-known/nostr.json/route.test.ts
+++ b/app/.well-known/nostr.json/route.test.ts
@@ -19,6 +19,7 @@ it("should return data with status 200", async () => {
     const body = await response.json()
 
     expect(response.status).toBe(200)
+    expect(response.headers.get("Access-Control-Allow-Origin")).toEqual("*")
     expect(body.names[name]).toBe(pubkey)
 })
 

--- a/app/.well-known/nostr.json/route.ts
+++ b/app/.well-known/nostr.json/route.ts
@@ -37,7 +37,11 @@ export async function GET(request: NextRequest) {
 
         return new Response(JSON.stringify(clientResponse), {
             status: 200,
-            headers: { "content-type": "application/json" }
+            headers: {
+                "content-type": "application/json",
+                // This next headers is so CORS policies don't restrict JS apps
+                "Access-Control-Allow-Origin": "*"
+            }
         })
     } catch (error: any) {
         console.error(error)


### PR DESCRIPTION
I tried to use our shiny new NIP-05 identifier and ran into what I think is a CORS issue that is described in the NIP: https://github.com/nostr-protocol/nips/blob/master/05.md#allowing-access-from-javascript-apps

Here are screenshots of what I saw when I tried to set our NIP-05 identifier to bitcoindevs@bitcoindevs.xyz in our nostr profile:

![Screenshot from 2025-01-15 11-38-32](https://github.com/user-attachments/assets/b3746ad5-e339-4ef9-b2c7-0adf8ef8975b)

![Screenshot from 2025-01-15 11-39-09](https://github.com/user-attachments/assets/a51d023f-d3ec-4ddb-8c7e-cf21ebce5322)

![Screenshot from 2025-01-15 11-39-29](https://github.com/user-attachments/assets/7d33fef2-60d3-4fcc-9358-c826df1bf33c)

To fix this, I followed the recommendations in the NIP and set the `Access-Control-Allow-Origin` response header to `*`

I'm not sure if the target branch for this merge should be master or staging. When I targeted staging it had a conflict that was basically nothing which I though was really weird.

