### PR TITLE
NIP-05: Add keys for 0tuedon and satsie

### DIFF
--- a/app/.well-known/nostr.json/nostr.json
+++ b/app/.well-known/nostr.json/nostr.json
@@ -1,6 +1,8 @@
 {
     "names": {
         "_": "78631371f159c1e696665da1a8b41546d75655b1085b4fe1a1a8d05b9a0d7a4e",
-        "bitcoindevs": "78631371f159c1e696665da1a8b41546d75655b1085b4fe1a1a8d05b9a0d7a4e"
+        "bitcoindevs": "78631371f159c1e696665da1a8b41546d75655b1085b4fe1a1a8d05b9a0d7a4e",
+        "0tuedon": "df5bb0ce1b14e48006050619f4600992442305e1b87df7efdb99ba16bec0f89f",
+        "satsie": "4df7b43b3a4db4b99e3dbad6bd0f84226726efd63ae7e027f91acbd91b4dba48"
     }
 }


### PR DESCRIPTION
Add keys for 0tuedon and satsie to the list of NIP-05 identifiers. Happy to add others to this PR!

To test this PR, verify that the public keys were converted to hex correctly. I used multiple web tools and compared the results:
- https://damus.io/key/
- https://nostrcheck.me/converter/

0tuedon's npub: https://njump.me/npub1madmpnsmznjgqps9qcvlgcqfjfzzxp0php7l0m7mnxapd0kqlz0sn74djz
satsie's npub: https://njump.me/npub1fhmmgwe6fk6tn83ahttt6ruyyfnjdm7k8tn7qflert9ajx6dhfyqf3nzcu