### PR TITLE
fix: set to 0 call counter when the cohort is completed

### DIFF
--- a/lib/utils/communities.ts
+++ b/lib/utils/communities.ts
@@ -388,7 +388,7 @@ END:VCALENDAR`
 export const getTimeUntilCall = (weeklyCall: WeeklyData["weeklyCall"]) => {
     const nextCall = getNextCallDate(weeklyCall)
     const now = new Date()
-    const diff = nextCall.getTime() - now.getTime()
+    const diff = Math.max(0, nextCall.getTime() - now.getTime())
 
     const days = Math.floor(diff / (1000 * 60 * 60 * 24))
     const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60))


### PR DESCRIPTION
# Description

The counter for the next call in [bitcoin-indonesia](https://bitcoindevs.xyz/decoding/communities/bitcoin-indonesia) was increasing the time when the program is already over. It is now set to 0 in that case.

## Change
<img width="344" alt="image" src="https://github.com/user-attachments/assets/e63e767e-965f-4ab6-a749-a5166ff8eacb" />


## Related issue

bitcoin-dev-project/decoding-bitcoin#40