### PR TITLE
Add ignore = dirty to .gitmodules to ignore submodule changes (#191)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,4 @@
 	path = public/decoding-bitcoin
 	url = https://github.com/bitcoin-dev-project/decoding-bitcoin/
 	branch = main
+	ignore = dirty


### PR DESCRIPTION
This PR updates the `.gitmodules` file to include `ignore = dirty` for the `public/decoding-bitcoin` submodule, as suggested in issue #191  by @satsie. This change prevents uncommitted submodule changes from appearing in the parent repo’s `git status`, making development smoother.

Closes #191