### PR TITLE
Fix time/day in cohort dashboard

### DIFF
--- a/components/communities/CommunityDashboardClient.tsx
+++ b/components/communities/CommunityDashboardClient.tsx
@@ -112,9 +112,8 @@ export default function CommunityDashboardClient({
                                                     ? "bg-orange-500 text-white"
                                                     : "bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-600"
                                             }
-                                            ${week > currentWeek ? "opacity-50 cursor-not-allowed" : ""}
+                                            ${week > currentWeek ? "opacity-50" : ""}
                                         `}
-                                        disabled={week > currentWeek}
                                     >
                                         {week}
                                     </button>
@@ -163,13 +162,12 @@ export default function CommunityDashboardClient({
                                                     onClick={() =>
                                                         setSelectedWeek(week)
                                                     }
-                                                    disabled={isLocked}
                                                     className={`
                                                         w-full flex items-center gap-3 p-4
                                                         transition-colors duration-200
                                                         hover:bg-gray-50 dark:hover:bg-gray-700/40
                                                         ${isSelected ? "bg-orange-50 dark:bg-orange-900/20 border-l-2 border-orange-500" : ""}
-                                                        ${isLocked ? "opacity-50 cursor-not-allowed" : ""}
+                                                        ${isLocked ? "opacity-50" : ""}
                                                     `}
                                                 >
                                                     <div

--- a/components/communities/WeeklyCallSection.tsx
+++ b/components/communities/WeeklyCallSection.tsx
@@ -15,6 +15,16 @@ export const WeeklyCallSection = ({ weekData }: { weekData: WeeklyData }) => {
         typeof getTimeUntilCall
     > | null>(null)
 
+    // Format the time based on the time object in weeklyCall
+    const formattedTime = weeklyCall.time
+        ? `${weeklyCall.time.hour}:${weeklyCall.time.minute.toString().padStart(2, "0")}`
+        : "20:00"
+
+    // Get day of week from the date
+    const dayOfWeek = new Date(weeklyCall.date).toLocaleDateString("en-US", {
+        weekday: "long"
+    })
+
     useEffect(() => {
         setTimeUntil(getTimeUntilCall(weeklyCall))
 
@@ -38,7 +48,7 @@ export const WeeklyCallSection = ({ weekData }: { weekData: WeeklyData }) => {
                         </p>
                     </div>
                     <p className="text-xs text-gray-600 dark:text-gray-400 hidden md:block">
-                        Every Friday • 8:00 AM (Bali)
+                        {`${dayOfWeek} • ${formattedTime} (${weeklyCall.time?.timeZone?.split("/").pop() || "Bali"})`}
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
This PR fixes wrong time/day handling in community dasboard and allow to view content for locked weeks