### PR TITLE
Added Hover Effect to Navbar Links

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -66,20 +66,22 @@ export function Header() {
                         />
                         <Link
                             href="/career"
-                            className="text-sm font-semibold leading-6 text-gray-800 dark:text-gray-100"
+                            className="text-sm font-semibold leading-6 text-gray-800 dark:text-gray-100 
+                            hover:text-orange-500 dark:hover:text-orange-400 transition-colors duration-300 ease-in-out
+                            "
                         >
                             Career
                         </Link>
 
                         <Link
                             href="/tools"
-                            className="text-sm font-semibold leading-6 text-gray-800 dark:text-gray-100"
+                            className="text-sm font-semibold leading-6 text-gray-800 dark:text-gray-100 hover:text-orange-500 dark:hover:text-orange-400 transition-colors duration-300 ease-in-out"
                         >
                             Tools
                         </Link>
                         <Link
                             href="/about"
-                            className="text-sm font-semibold leading-6 text-gray-800 dark:text-gray-100"
+                            className="text-sm font-semibold leading-6 text-gray-800 dark:text-gray-100 hover:text-orange-500 dark:hover:text-orange-400 transition-colors duration-300 ease-in-out"
                         >
                             About
                         </Link>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -250,7 +250,7 @@ function PopoverNavigation({
             <PopoverButton
                 as="button"
                 onClick={() => setOpen(!isOpen)}
-                className="flex items-center gap-x-1 text-sm font-semibold leading-6 text-gray-800 dark:text-gray-100"
+                className="flex items-center gap-x-1 text-sm font-semibold leading-6 text-gray-800 dark:text-gray-100 hover:text-orange-500 dark:hover:text-orange-400 transition-colors duration-300 ease-in-out px-4 py-2"
                 ref={contentRef}
             >
                 {navItem}


### PR DESCRIPTION
This PR improves the user experience by adding a hover effect to the navigation links (`Career`, `Tools`, `About`). Previously, these links lacked interactive feedback when hovered over.

Fixes #202


### Changes Implemented
Added `hover:text-orange-500 dark:hover:text-orange-400 transition-colors duration-300 ease-in-out` to navigation links.
Ensures smooth color transitions for better UX.
Supports both light and dark mode.

### Before & After👇

https://github.com/user-attachments/assets/6649f688-2bb7-4511-8731-09e252efe515

👋@satsie, Please review this PR and merge it. Let me know if any changes are required. Thank you