### PR TITLE
Add /grants route proxy to grants app

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -17,6 +17,18 @@ module.exports = () => {
         },
         images: {
             domains: ["avatars.githubusercontent.com"]
+        },
+        async rewrites() {
+            return [
+                {
+                    source: '/grants',
+                    destination: 'https://grant-common-app.vercel.app/'
+                },
+                {
+                    source: '/grants/:path*',
+                    destination: 'https://grant-common-app.vercel.app/:path*'
+                }
+            ]
         }
     })
 }

--- a/next.config.js
+++ b/next.config.js
@@ -21,12 +21,12 @@ module.exports = () => {
         async rewrites() {
             return [
                 {
-                    source: '/grants',
-                    destination: 'https://grant-common-app.vercel.app/'
+                    source: "/grants",
+                    destination: "https://grant-common-app.vercel.app/"
                 },
                 {
-                    source: '/grants/:path*',
-                    destination: 'https://grant-common-app.vercel.app/:path*'
+                    source: "/grants/:path*",
+                    destination: "https://grant-common-app.vercel.app/:path*"
                 }
             ]
         }


### PR DESCRIPTION
Adds Next.js rewrites to proxy requests from `/grants` to the grants app at `https://grant-common-app.vercel.app`.

This allows users to access the grants app at `https://bitcoindevs.xyz/grants` without merging repositories.
