### PR TITLE
fix: correct swapped descriptions for tool and seminar

### DIFF
--- a/utils/index.ts
+++ b/utils/index.ts
@@ -49,7 +49,7 @@ export const FILTERSGUIDE: FilterResourceType[] = [
     },
     {
         tag: "tool",
-        description: "Lecture, talks"
+        description: "Utility or reference to explore"
     },
     {
         tag: "interactive",
@@ -57,7 +57,7 @@ export const FILTERSGUIDE: FilterResourceType[] = [
     },
     {
         tag: "seminar",
-        description: "Utility or reference to explore"
+        description: "Lecture, talks"
     }
 ]
 


### PR DESCRIPTION
Fixes Issue :Change legend description on learn/contribute pages #274


This PR fixes an issue where the descriptions for the "Tool" and "Seminar" resource types were swapped in the filters legend.

Changes made:
- Updated the description for "Tool" to: "Utility or reference to explore"
- Updated the description for "Seminar" to: "Lecture, talks"

This is my first contribution to the Bitcoin Dev Project, and I’m really happy to be learning and contributing here. Thankyou for the helpful issue labels and guidance!  :))

Before : 
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/f72cf9bc-752f-474a-91b2-ce183c94e370" />

After : 
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/b0cce7bb-25cd-401b-a72c-9b3b70c32342" />

