### PR TITLE
Fix saving satoshi link

### DIFF
--- a/public/learn/index.json
+++ b/public/learn/index.json
@@ -90,7 +90,7 @@
       "logo": "/images/learn/savingsatoshi.webp",
       "title": "Saving Satoshi",
       "description": "An interactive science fiction game designed to inspire a generation to fall in love with bitcoin.",
-      "link": "https://chat.bitcoinsearch.xyz/"
+      "link": "https://savingsatoshi.com"
     },
     {
       "difficulty": "medium",


### PR DESCRIPTION

**Description:**
The Saving Satoshi card on the /learn page was incorrectly linking to ChatBTC.
This PR updates the link to point to the official Saving Satoshi website.

Fixes #279 

**Before**
Saving Satoshi → ChatBTC (incorrect)

https://github.com/user-attachments/assets/f5392149-234e-4bdb-87f9-469b30236d9d


**After**
Saving Satoshi → https://savingsatoshi.com/ (correct)

https://github.com/user-attachments/assets/ab873b04-7ae9-4019-bd83-7e7e7f0c89f3


**Why this change**
Ensures users are redirected to the correct learning resource and improves accuracy of the Learn page content.

**Testing**
Verified link locally on the /learn page
Confirmed correct redirection to the official Saving Satoshi site