### PR TITLE
fixing-empty-request.json() attacks

### DIFF
--- a/app/subscribe/route.ts
+++ b/app/subscribe/route.ts
@@ -7,8 +7,21 @@ import mailchimp from "@mailchimp/mailchimp_marketing"
 configureMailchimp()
 
 export async function POST(request: NextRequest) {
+    let body
+    
     try {
-        const body = await request.json()
+        body = await request.json()
+    } 
+    catch (error) {
+        return new Response(
+            JSON.stringify({ error: "Request body is empty or invalid JSON" }),
+            {
+                status: 400,
+                headers: { "content-type": "application/json" },
+            }
+        )
+    }
+    try {
         if (!body.email) {
             throw new Error("Email is required")
         }


### PR DESCRIPTION
 fixes #284 
 
 **I have wrapped the request.json() call in its own try/catch block. This ensures that if the body is empty or contains malformed JSON, the server returns a 400 Bad Request immediately, rather than crashing or falling through to a generic 500 error.**
 
 @0tuedon  Please review