### PR TITLE
fix: update BOSS Projects page styling and footer layout (#297)

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -194,9 +194,9 @@ export default function Projects() {
 
 function ProjectCardComponent({ project }: { project: ProjectCard }) {
     return (
-        <div className="relative flex h-full flex-col rounded-[16px] border-2 border-[#e1dbd0] bg-[#efe9de] overflow-hidden p-2">
+        <div className="relative flex h-full flex-col rounded-[16px] border border-[#e1dbd0] bg-[#efe9de] overflow-hidden p-2">
             {/* INNER BORDER - Card Content Area */}
-            <div className="flex flex-col h-full border-2 border-[#e1dbd0] rounded-[14px] overflow-hidden">
+            <div className="flex flex-col h-full border border-[#e1dbd0] rounded-[14px] overflow-hidden">
                 {/* IMAGE SECTION - Full width, no padding */}
                 <div className="relative w-full">
                     {/* BDP tag positioned on top of image */}
@@ -224,10 +224,10 @@ function ProjectCardComponent({ project }: { project: ProjectCard }) {
 
                 {/* BOTTOM / CONTENT SECTION */}
                 <div className="bg-[#efe9de] text-black p-4 flex flex-1 flex-col">
-                    <h3 className="text-2xl font-bold mb-2 font-montserrat">
+                    <h3 className="text-[17px] font-bold mb-2 font-montserrat leading-tight">
                         {project.title}
                     </h3>
-                    <p className="text-base mb-4 flex-1 opacity-70">
+                    <p className="text-base opacity-70 mb-6">
                         {project.description}
                     </p>
 
@@ -235,22 +235,22 @@ function ProjectCardComponent({ project }: { project: ProjectCard }) {
                     <Link
                         href={project.link}
                         rel="noopener noreferrer"
-                        className="relative inline-flex items-center h-8 rounded-[20px] font-semibold text-xs transition-all hover:scale-105
-                bg-[#E1DBD0] border-2 border-[#C7C1B6] text-black overflow-hidden self-start"
+                        className="group relative mt-auto inline-flex items-center h-10 rounded-[24px] font-semibold text-base transition-all hover:scale-105 hover:bg-[#D4CEC1]
+                bg-[#E1DBD0] border border-[#C7C1B6] text-black overflow-hidden self-start"
                     >
                         {/* Inner circle on left - full height, matches button height */}
-                        <span className="absolute -left-[2px] -top-[2px] h-8 w-8 rounded-full border-2 border-[#C7C1B6] flex items-center justify-center flex-shrink-0">
-                            <GithubNewIcon width={14} className="text-black" />
+                        <span className="absolute -left-[1px] -top-[1px] h-10 w-10 rounded-full border border-[#C7C1B6] flex items-center justify-center flex-shrink-0 transition-colors group-hover:bg-[#C7C1B6]">
+                            <GithubNewIcon width={20} className="text-black" />
                         </span>
 
                         {/* Text content */}
-                        <span className="ml-10 mr-2.5">
+                        <span className="ml-12 mr-3">
                             {project.buttonText || "Good First Issues"}
                         </span>
 
                         {/* Arrow */}
-                        <span className="mr-2.5">
-                            <RightArrowIcon width={12} className="text-black" />
+                        <span className="mr-3">
+                            <RightArrowIcon width={16} className="text-black" />
                         </span>
                     </Link>
                 </div>

--- a/components/footer-component.tsx
+++ b/components/footer-component.tsx
@@ -5,7 +5,7 @@ import clsx from "clsx"
 
 const FooterComponent = () => {
     return (
-        <footer className="relative min-h-[944px] md:min-h-[1000px] lg:min-h-[766px] pt-20 lg:pt-[129px]  bg-brand bg-footer-mobile md:bg-footer bg-cover bg-bottom bg-no-repeat  lg:bg-cover">
+        <footer className="relative min-h-[944px] md:min-h-[1000px] lg:min-h-[766px] pt-12 lg:pt-16  bg-brand bg-footer-mobile md:bg-footer bg-cover bg-bottom bg-no-repeat  lg:bg-cover">
             <div className="flex flex-col p-5 lg:flex-row w-full gap-10 max-w-[583px] lg:mx-auto justify-between font-quicksand font-bold">
                 {FOOTERLINKS.map((link) => (
                     <div key={link.name}>
@@ -30,16 +30,16 @@ const FooterComponent = () => {
                             </div>
                         )}
                         {link.name === "contact" && (
-                            <div className="flex flex-row gap-2 mt-2.5">
+                            <div className="flex flex-row gap-3 mt-2.5">
                                 {link.links.map((subLink) => (
                                     <a
                                         key={subLink.name}
                                         href={subLink.link}
                                         target={subLink.target}
-                                        className="bg-brand-gray text-brand-gray-200/75 hover:text-brand-orange-100  border rounded-[4px] w-[44px] h-[44px] flex items-center justify-center  border-brand-gray-100"
+                                        className="bg-brand-gray text-brand-gray-200/75 hover:text-brand-orange-100 hover:bg-brand-orange-100/10 hover:border-brand-orange-100 border rounded-[6px] w-[52px] h-[52px] flex items-center justify-center border-brand-gray-100 transition-all duration-200 hover:scale-110"
                                     >
                                         {subLink?.component && (
-                                            <subLink.component />
+                                            <subLink.component className="w-6 h-6" />
                                         )}
                                     </a>
                                 ))}


### PR DESCRIPTION
- Reduce card border widths from 2px to 1px (inner and outer)
- Reduce card heading font size from 24px to 17px
- Fix gap between description and CTA button for consistency
- Increase CTA button font size to 1rem (16px) with larger icons
- Add subtle hover effect to CTA button with contrasting background
- Move footer sections higher from grass background
- Enlarge contact icons from 44px to 52px with hover effects

Resolves #297

## refer attached screenshots for the changes made
<img width="1177" height="657" alt="Screenshot_20260205_223730" src="https://github.com/user-attachments/assets/4e70478e-f81a-4d9a-b92b-52e6c2660476" />
<img width="728" height="255" alt="Screenshot_20260205_223826" src="https://github.com/user-attachments/assets/a282fd87-69c1-423b-bd60-41051edfe5c9" />


