### PR TITLE
feat: add hover stroke to resource cards

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -112,3 +112,11 @@ select:-webkit-autofill:focus {
     height: auto;
     object-fit: contain;
 }
+
+.learn-cards-container > a {
+    transition: border-color 0.2s ease;
+}
+
+.learn-cards-container > a:hover {
+    border-color: rgba(169, 164, 155, 0.75);
+}


### PR DESCRIPTION
## Summary
- Adds a `border-color` hover transition to resource cards on the learn and contribute pages
- Hover color is `rgba(169, 164, 155, 0.75)` as specified in the [Figma design](https://www.figma.com/design/vz8aDaQxVLl8lw3wdv2CD3/BDP-Website?node-id=854-15529&t=kg777Ho0mFGvF7px-0)
- Smooth 0.2s ease transition for the border color change

## Test plan
- [x] Lint passes with no new warnings
- [x] CSS targets `.learn-cards-container > a` which wraps all BDPCard components on learn/contribute pages
- [x] Hover effect only applies to direct child anchor elements (resource cards)

Closes #295