### PR TITLE
feat: show not-found card when no resources match filters

### DIFF
--- a/components/brand/CardContainers.tsx
+++ b/components/brand/CardContainers.tsx
@@ -3,6 +3,32 @@ import { ICurriculum } from "@/types/curriculum"
 import { BDPCard } from "@bitcoin-dev-project/bdp-ui"
 import React from "react"
 
+const ResourceNotFound = () => (
+    <div className="border border-brand-stroke-on-base p-6 flex flex-col items-center justify-center min-h-[290px] w-full rounded-2xl bg-brand-card-bg col-span-full">
+        <svg
+            width="48"
+            height="48"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="text-brand-gray-200 mb-4"
+        >
+            <circle cx="11" cy="11" r="8" />
+            <line x1="21" y1="21" x2="16.65" y2="16.65" />
+            <line x1="8" y1="11" x2="14" y2="11" />
+        </svg>
+        <h6 className="font-montserrat text-lg font-semibold text-brand-dark mb-1">
+            No resources found
+        </h6>
+        <p className="font-quicksand text-sm text-brand-gray-300 text-center">
+            Try adjusting your search or filters
+        </p>
+    </div>
+)
+
 const CardContainers: React.FC<ICurriculum> = ({ allCurriculum }) => {
     if (!allCurriculum) {
         return null
@@ -10,13 +36,17 @@ const CardContainers: React.FC<ICurriculum> = ({ allCurriculum }) => {
 
     return (
         <div className="learn-cards-container grid md:grid-cols-2 justify-between w-full gap-5">
-            {allCurriculum.map((curriculum, index) => (
-                <BDPCard
-                    key={`${curriculum.title}-${curriculum.link}-${index}`}
-                    onClick={() => {}}
-                    {...curriculum}
-                />
-            ))}
+            {allCurriculum.length === 0 ? (
+                <ResourceNotFound />
+            ) : (
+                allCurriculum.map((curriculum, index) => (
+                    <BDPCard
+                        key={`${curriculum.title}-${curriculum.link}-${index}`}
+                        onClick={() => {}}
+                        {...curriculum}
+                    />
+                ))
+            )}
         </div>
     )
 }


### PR DESCRIPTION
## Summary
- Adds a styled empty state card when search/difficulty/tag filters produce zero results
- Card uses the same `brand-card-bg` and `border-brand-stroke-on-base` styling as resource cards
- Shows a search icon, "No resources found" heading, and "Try adjusting your search or filters" helper text
- Uses `col-span-full` to center across the grid

Matches the design from the [Figma spec](https://www.figma.com/design/vz8aDaQxVLl8lw3wdv2CD3/BDP-Website?node-id=854-15529&t=kg777Ho0mFGvF7px-0).

## Test plan
- [x] Lint passes with no new warnings
- [x] Empty state renders when `allCurriculum` array is empty (filtered to zero results)
- [x] Normal card rendering unchanged when results exist

Closes #296