### PR TITLE
fix: handle empty/invalid JSON body in subscribe route

### DIFF
--- a/app/subscribe/route.ts
+++ b/app/subscribe/route.ts
@@ -8,7 +8,19 @@ configureMailchimp()
 
 export async function POST(request: NextRequest) {
     try {
-        const body = await request.json()
+        let body
+        try {
+            body = await request.json()
+        } catch {
+            return new Response(
+                JSON.stringify({ error: "Invalid or empty request body" }),
+                {
+                    status: 400,
+                    headers: { "content-type": "application/json" }
+                }
+            )
+        }
+
         if (!body.email) {
             throw new Error("Email is required")
         }


### PR DESCRIPTION
## Summary

Fixes #284 — `request.json()` throws an unhandled `SyntaxError` when a POST request has an empty or invalid JSON body, resulting in a 500 error instead of a proper 400 response.

## Changes

Wraps `request.json()` in a dedicated try/catch that returns a 400 JSON response (`"Invalid or empty request body"`) before reaching the email validation or Mailchimp API call.

## Test plan

- [x] TypeScript compiles (`npx tsc --noEmit` — clean)
- [x] Vercel preview deployment (pending CI)