### PR TITLE
Enable Multi-Select for Difficulty Filter #307

### DIFF
--- a/components/brand/Filters.tsx
+++ b/components/brand/Filters.tsx
@@ -38,7 +38,11 @@ const Filters: React.FC<IFilters> = () => {
     }
 
     const handleDifficultyClick = (level: Difficulty) => {
-        setDifficulty(difficulty === level ? "" : level)
+        setDifficulty((prev) =>
+            prev.includes(level)
+                ? prev.filter((d) => d !== level)
+                : [...prev, level]
+        )
     }
 
     return (
@@ -103,7 +107,7 @@ const Filters: React.FC<IFilters> = () => {
                                     className={`cursor-pointer transition-opacity`}
                                 >
                                     <Leaf
-                                        selected={difficulty === level}
+                                        selected={difficulty.includes(level)}
                                         leavesCount={count}
                                         withBorder
                                     />
@@ -181,7 +185,7 @@ const Filters: React.FC<IFilters> = () => {
                                     className={`cursor-pointer transition-opacity`}
                                 >
                                     <Leaf
-                                        selected={difficulty === level}
+                                        selected={difficulty.includes(level)}
                                         leavesCount={count}
                                         withBorder
                                     />

--- a/context/FilterContext.tsx
+++ b/context/FilterContext.tsx
@@ -19,8 +19,8 @@ interface CurriculumContextProps {
     filteredCurriculum: Curriculum[]
     search: string
     setSearch: Dispatch<SetStateAction<string>>
-    difficulty: Difficulty | ""
-    setDifficulty: (value: Difficulty | "") => void
+    difficulty: Difficulty[]
+    setDifficulty: Dispatch<SetStateAction<Difficulty[]>>
     selectedTags: TagType[]
     setSelectedTags: Dispatch<SetStateAction<TagType[]>>
     handleInputChange: (e: ChangeEvent<HTMLInputElement>) => void
@@ -41,7 +41,7 @@ export const CurriculumProvider = ({
     path
 }: CurriculumProviderProps) => {
     const [search, setSearch] = useState("")
-    const [difficulty, setDifficulty] = useState<Difficulty | "">("")
+    const [difficulty, setDifficulty] = useState<Difficulty[]>([])
     const [selectedTags, setSelectedTags] = useState<TagType[]>([])
     const [curriculum, setCurriculum] = useState<Curriculum[]>([])
 
@@ -52,9 +52,10 @@ export const CurriculumProvider = ({
                 item.title.toLowerCase().includes(lowerSearch) ||
                 item.description.toLowerCase().includes(lowerSearch)
 
-            const matchesDifficulty = difficulty
-                ? item.difficulty === difficulty
-                : true
+            const matchesDifficulty =
+                difficulty.length === 0
+                    ? true
+                    : difficulty.includes(item.difficulty)
 
             const matchesTags =
                 selectedTags.length === 0
@@ -71,7 +72,7 @@ export const CurriculumProvider = ({
 
     const clearFilters = useCallback(() => {
         setSearch("")
-        setDifficulty("")
+        setDifficulty([])
         setSelectedTags([])
     }, [])
 


### PR DESCRIPTION
# Description
This PR implements multi-select functionality for the difficulty filter on the Learn and Contribute pages, allowing users to select multiple difficulty levels simultaneously (easy, medium, and/or hard).

## Problem
Previously, users could only select ONE difficulty level at a time. The "resource difficulty" filter acted the same way as the "resource type" filter in implementation, but didn't allow multiple selections like resource types did. This was inconsistent and limiting for users who wanted to view resources across multiple difficulty levels.

## Solution
Changed the difficulty filter to work exactly like the resource type filter:

Click a difficulty leaf to add it to active filters
Click again to remove it from active filters
Multiple difficulties can be selected simultaneously
Clear Filters button resets all selections

# Testing
- No TypeScript errors
- No ESLint errors
- Consistent behavior with resource type filter
- Works on both desktop and mobile views
- Clear filters functionality works correctly

Closes #307