### PR TITLE
chore: remove bdk issues

### DIFF
--- a/public/open-source-projects/issues/bdk/index.json
+++ b/public/open-source-projects/issues/bdk/index.json
@@ -11,16 +11,6 @@
     "imageUrl": "https://avatars.githubusercontent.com/u/62867074?v=4"
   },
   {
-    "url": "https://github.com/bitcoindevkit/bdk/issues/1936",
-    "publishedAt": "2024-12-03T12:02:57Z",
-    "title": "Move `TxTemplate` to `bdk_testenv` and make it better",
-    "labels": [
-      "good first issue",
-      "tests"
-    ],
-    "imageUrl": "https://avatars.githubusercontent.com/u/62867074?v=4"
-  },
-  {
     "url": "https://github.com/bitcoindevkit/bdk/issues/2088",
     "publishedAt": "2026-01-03T21:39:04Z",
     "title": "`CanonicalReason::Assumed` should map to `ChainPosition::Confirmed` if a direct anchor exists",


### PR DESCRIPTION
Remove the entry for  as it already has an active PR addressing it:
- https://github.com/bitcoindevkit/bdk/issues/2021
- https://github.com/bitcoindevkit/bdk/issues/1936