### PR TITLE
feat: add hover interaction on resource cards

### DIFF
--- a/components/brand/CardContainers.tsx
+++ b/components/brand/CardContainers.tsx
@@ -16,11 +16,15 @@ const CardContainers: React.FC<ICurriculum> = ({ allCurriculum }) => {
     return (
         <div className="learn-cards-container grid md:grid-cols-2 justify-between w-full gap-5">
             {allCurriculum.map((curriculum, index) => (
-                <BDPCard
+                <div 
                     key={`${curriculum.title}-${curriculum.link}-${index}`}
-                    onClick={() => { }}
-                    {...curriculum}
-                />
+                    className="rounded-2xl transition-all duration-300 hover:ring-1 hover:ring-[rgba(169,164,155,0.75)] hover:shadow-sm"
+                >
+                    <BDPCard
+                        onClick={() => { }}
+                        {...curriculum}
+                    />
+                </div>
             ))}
         </div>
     )


### PR DESCRIPTION
## Summary
Added stroke on hover to resource cards on the learn and contri pages as requested.

## Problem
Closes #295

## Solution
Wrapped the `BDPCard` component inside a `div` with `hover:ring-1 hover:ring-[rgba(169,164,155,0.75)] rounded-2xl` to add the requested stroke interaction, avoiding modifying the external `BDPCard` package directly while ensuring the desired hover effect.

## Testing
- [x] Tested locally with `npm run build` and `npm test`
