### PR TITLE
add links & hover animation to logos

### DIFF
--- a/components/landing-page/hero-page.tsx
+++ b/components/landing-page/hero-page.tsx
@@ -110,7 +110,10 @@ const HeroPage = ({
                         {FEATUREDLOGOS.map((item) => (
                             <a
                                 key={item.name}
-                                className="relative rounded-xl w-[153px] h-[109px] md:w-48 md:h-32 flex flex-col items-center justify-center transition-all"
+                                href={item.link}
+                                target={item.target ?? "_blank"}
+                                rel="noreferrer"
+                                className="relative rounded-xl w-[153px] h-[109px] md:w-48 md:h-32 flex flex-col items-center justify-center transition-all duration-200 hover:scale-110 hover:-translate-y-1"
                             >
                                 <div className="text-center flex flex-col items-center justify-center gap-3">
                                     <Image

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -197,23 +197,33 @@ export const NAVLINKS = [
 export const FEATUREDLOGOS = [
     {
         name: "Summer of Bitcoin",
-        logo: "/images/hero/summer-of-bitcoin.webp"
+        logo: "/images/hero/summer-of-bitcoin.webp",
+        link: "https://medium.com/@nandiniarora584/from-oops-wrong-link-to-saving-satoshi-my-bitcoin-design-summer-adventure-fe6e4a0f75da",
+        target: "_blank"
     },
     {
         name: "Coindesk",
-        logo: "/images/hero/coin-desk.webp"
+        logo: "/images/hero/coin-desk.webp",
+        link: "https://www.coindesk.com/tech/2023/08/07/its-chatgpt-but-for-bitcoin-new-ai-tool-avoids-hallucinations",
+        target: "_blank"
     },
     {
         name: "Btrust",
-        logo: "/images/hero/btrust.webp"
+        logo: "/images/hero/btrust.webp",
+        link: "https://pathways.btrust.tech/resource-hub#open-source-cheat-sheets",
+        target: "_blank"
     },
     {
         name: "Stacker News",
-        logo: "/images/hero/stacker-news.webp"
+        logo: "/images/hero/stacker-news.webp",
+        link: "https://www.youtube.com/watch?v=CBOhiw1yAWY&t=2010s",
+        target: "_blank"
     },
     {
         name: "Stephan Livera",
-        logo: "/images/hero/stephan-livera.webp"
+        logo: "/images/hero/stephan-livera.webp",
+        link: "https://stephanlivera.com/episode/620/",
+        target: "_blank"
     }
 ]
 


### PR DESCRIPTION
This pr fixes #317 and adds the correct destination links to the  "Featured In" logos section on the homepage, as suggested in the [Figma design](https://www.figma.com/design/vz8aDaQxVLl8lw3wdv2CD3/BDP-Website?node-id=1288-35415&p=f&t=jTNSoAHQCl4UfYhp-0).

### Changes Made
- Added destination links to the "Featured In" logo section
- Added a hover animation to indicate that the logos are clickable

### Demo

https://github.com/user-attachments/assets/f3fa3e35-d4d2-42d9-94ae-245f78868c17

cc: @satsie @sanya031 @jrakibi for review.

