### PR TITLE
add a permanent redirect from /explore to /learn

### DIFF
--- a/components/conditional-background.tsx
+++ b/components/conditional-background.tsx
@@ -10,7 +10,7 @@ export function ConditionalBackground({
     const pathname = usePathname()
 
     // Apply rebranded background color to these pages
-    const rebrandedPages = ["/projects", "/career", "/about", "/explore", "/"]
+    const rebrandedPages = ["/projects", "/career", "/about", "/"]
     const isRebrandedPage = rebrandedPages.some(
         (page) =>
             pathname === page || (page !== "/" && pathname?.startsWith(page))

--- a/components/conditional-body.tsx
+++ b/components/conditional-body.tsx
@@ -17,13 +17,7 @@ export function ConditionalBody({
     const pathname = usePathname()
 
     // Apply rebranded background color to these pages
-    const rebrandedPages = [
-        "/projects",
-        "/get",
-        "/about",
-        "/",
-        "/career"
-    ]
+    const rebrandedPages = ["/projects", "/get", "/about", "/", "/career"]
     const isRebrandedPage = rebrandedPages.some(
         (page) =>
             pathname === page || (page !== "/" && pathname?.startsWith(page))

--- a/components/conditional-body.tsx
+++ b/components/conditional-body.tsx
@@ -21,7 +21,6 @@ export function ConditionalBody({
         "/projects",
         "/get",
         "/about",
-        "/explore",
         "/",
         "/career"
     ]

--- a/components/conditional-header.tsx
+++ b/components/conditional-header.tsx
@@ -12,7 +12,6 @@ export function ConditionalHeader() {
         "/projects",
         "/get-funded",
         "/about",
-        "/explore",
         "/learn",
         "/contribute"
     ]

--- a/next.config.js
+++ b/next.config.js
@@ -38,10 +38,10 @@ module.exports = () => {
                     permanent: false
                 },
                 {
-                    source: '/explore',
-                    destination: '/learn',
+                    source: "/explore",
+                    destination: "/learn",
                     permanent: true
-                },
+                }
             ]
         },
         async rewrites() {

--- a/next.config.js
+++ b/next.config.js
@@ -36,7 +36,12 @@ module.exports = () => {
                     destination:
                         "https://medium.com/@bitcoindevs/glow-up-95008146d653",
                     permanent: false
-                }
+                },
+                {
+                    source: '/explore',
+                    destination: '/learn',
+                    permanent: true
+                },
             ]
         },
         async rewrites() {

--- a/utils/index.tsx
+++ b/utils/index.tsx
@@ -191,7 +191,7 @@ export const NAVLINKS = [
     },
     {
         name: "Explore",
-        link: "/explore"
+        link: "/learn"
     }
 ]
 


### PR DESCRIPTION
This pr fixes #332 by replacing all `/explore` links with `/learn` and adding a permanent redirect to handle any old indexed `/explore` paths.

## Demo

https://github.com/user-attachments/assets/b3b0d3d4-f1a1-4243-8133-6434e5ff21d6

