### PR TITLE
fix: faq partially hidden by background image on wide screens

### DIFF
--- a/components/landing-page/faq-section.tsx
+++ b/components/landing-page/faq-section.tsx
@@ -7,7 +7,7 @@ const FaqSection = () => {
         setExpandedFaq(expandedFaq === index ? null : index)
     }
     return (
-        <div className="bg-[#F5EFE7] py-24">
+        <div className="bg-[#F5EFE7] py-24 relative">
             <div className="max-w-4xl mx-auto px-5 lg:px-8">
                 <h2 className="text-2xl font-bold text-brand-dark text-center mb-12 font-montserrat">
                     FREQUENTLY ASKED QUESTIONS


### PR DESCRIPTION
fix #350 

Since the CSS property `position` changes the position of an element in the document flow, and the document flow still looks good to me, I think this didn't break anything else.

https://github.com/user-attachments/assets/ecdc4251-440b-449e-91c5-837c6fad28d0