### PR TITLE
Reduce client-side js

### DIFF
--- a/app/decoding/communities/page.tsx
+++ b/app/decoding/communities/page.tsx
@@ -3,7 +3,8 @@
 import { useState } from "react"
 import Link from "next/link"
 import Image from "next/image"
-import { motion } from "framer-motion"
+import * as m from "framer-motion/m"
+import { LazyMotion, domAnimation } from "framer-motion"
 import { HiUsers, HiClock, HiGlobe, HiArrowRight } from "react-icons/hi"
 import { FaDiscord, FaRocket } from "react-icons/fa"
 import { getAllCommunities } from "@/lib/utils/communities"
@@ -72,89 +73,90 @@ export default function CommunitiesPage() {
     })
 
     return (
-        <div className="min-h-screen bg-white dark:bg-gradient-to-b dark:from-gray-900 dark:to-gray-950">
-            <div className="relative border-b border-gray-200 dark:border-gray-800">
-                <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,_var(--tw-gradient-stops))] from-orange-100/50 via-white to-transparent dark:from-orange-500/20 dark:via-black dark:to-transparent opacity-70" />
-                <div className="relative max-w-7xl mx-auto px-4 py-12">
-                    <motion.div
-                        initial={{ opacity: 0, y: 20 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        className="text-center space-y-6"
-                    >
-                        <div
-                            className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full 
+        <LazyMotion features={domAnimation}>
+            <div className="min-h-screen bg-white dark:bg-gradient-to-b dark:from-gray-900 dark:to-gray-950">
+                <div className="relative border-b border-gray-200 dark:border-gray-800">
+                    <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,_var(--tw-gradient-stops))] from-orange-100/50 via-white to-transparent dark:from-orange-500/20 dark:via-black dark:to-transparent opacity-70" />
+                    <div className="relative max-w-7xl mx-auto px-4 py-12">
+                        <m.div
+                            initial={{ opacity: 0, y: 20 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            className="text-center space-y-6"
+                        >
+                            <div
+                                className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full 
                             bg-gradient-to-r from-orange-100 to-orange-50 dark:from-orange-500/10 dark:to-orange-500/5 
                             border border-orange-200 dark:border-orange-500/20"
-                        >
-                            <FaRocket className="w-4 h-4 text-orange-600 dark:text-orange-400" />
-                            <span className="text-sm font-medium text-orange-600 dark:text-orange-400">
-                                Community-Led Bitcoin Education
-                            </span>
-                        </div>
-
-                        <div className="space-y-4">
-                            <h1 className="text-3xl md:text-5xl font-bold text-gray-900 dark:text-white">
-                                Bitcoin Communities
-                                <span className="block text-transparent bg-clip-text bg-gradient-to-r from-orange-500 to-orange-600 dark:from-orange-400 dark:to-orange-500 leading-[1.2] pb-1 md:pb-2 pt-1 md:pt-2">
-                                    Running Study Cohorts
+                            >
+                                <FaRocket className="w-4 h-4 text-orange-600 dark:text-orange-400" />
+                                <span className="text-sm font-medium text-orange-600 dark:text-orange-400">
+                                    Community-Led Bitcoin Education
                                 </span>
-                            </h1>
+                            </div>
 
-                            <p className="text-gray-600 dark:text-gray-400 max-w-2xl mx-auto text-base md:text-lg">
-                                Join these Bitcoin communities as they guide
-                                their members through structured learning
-                                programs with weekly discussions and hands-on
-                                development.
-                            </p>
-                        </div>
+                            <div className="space-y-4">
+                                <h1 className="text-3xl md:text-5xl font-bold text-gray-900 dark:text-white">
+                                    Bitcoin Communities
+                                    <span className="block text-transparent bg-clip-text bg-gradient-to-r from-orange-500 to-orange-600 dark:from-orange-400 dark:to-orange-500 leading-[1.2] pb-1 md:pb-2 pt-1 md:pt-2">
+                                        Running Study Cohorts
+                                    </span>
+                                </h1>
 
-                        <div className="inline-flex items-center gap-6 px-6 py-3 rounded-xl bg-gray-50 dark:bg-gray-800/30 border border-gray-200 dark:border-gray-700/50">
-                            <div className="text-left">
-                                <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
-                                    Want to use Decoding Bitcoin for your next
-                                    cohort?
-                                </h3>
-                                <p className="text-sm text-gray-600 dark:text-gray-400">
-                                    Let us know and we'll create a custom
-                                    dashboard for your community.
+                                <p className="text-gray-600 dark:text-gray-400 max-w-2xl mx-auto text-base md:text-lg">
+                                    Join these Bitcoin communities as they guide
+                                    their members through structured learning
+                                    programs with weekly discussions and
+                                    hands-on development.
                                 </p>
                             </div>
-                            <Link
-                                href="mailto:info@bitcoindevs.xyz"
-                                className="flex items-center gap-2 px-4 py-2 bg-orange-500 hover:bg-orange-600 
+
+                            <div className="inline-flex items-center gap-6 px-6 py-3 rounded-xl bg-gray-50 dark:bg-gray-800/30 border border-gray-200 dark:border-gray-700/50">
+                                <div className="text-left">
+                                    <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+                                        Want to use Decoding Bitcoin for your
+                                        next cohort?
+                                    </h3>
+                                    <p className="text-sm text-gray-600 dark:text-gray-400">
+                                        Let us know and we'll create a custom
+                                        dashboard for your community.
+                                    </p>
+                                </div>
+                                <Link
+                                    href="mailto:info@bitcoindevs.xyz"
+                                    className="flex items-center gap-2 px-4 py-2 bg-orange-500 hover:bg-orange-600 
                                     text-white rounded-lg transition-all duration-200 whitespace-nowrap
                                     hover:translate-y-[-1px]"
-                            >
-                                Contact Us
-                                <HiArrowRight className="w-4 h-4" />
-                            </Link>
-                        </div>
-                    </motion.div>
+                                >
+                                    Contact Us
+                                    <HiArrowRight className="w-4 h-4" />
+                                </Link>
+                            </div>
+                        </m.div>
+                    </div>
                 </div>
-            </div>
 
-            <div className="sticky top-0 z-10 bg-white/80 dark:bg-gray-900/80 backdrop-blur-xl border-b border-gray-200 dark:border-gray-800">
-                <div className="max-w-7xl mx-auto px-4 py-3">
-                    <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-4">
-                            <Link
-                                href="/decoding"
-                                className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-gray-100 dark:bg-gray-800/50 text-gray-600 dark:text-gray-400 
+                <div className="sticky top-0 z-10 bg-white/80 dark:bg-gray-900/80 backdrop-blur-xl border-b border-gray-200 dark:border-gray-800">
+                    <div className="max-w-7xl mx-auto px-4 py-3">
+                        <div className="flex items-center justify-between">
+                            <div className="flex items-center gap-4">
+                                <Link
+                                    href="/decoding"
+                                    className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-gray-100 dark:bg-gray-800/50 text-gray-600 dark:text-gray-400 
                                 hover:bg-gray-200 dark:hover:bg-gray-800/80 hover:text-gray-900 dark:hover:text-white transition-all duration-200"
-                            >
-                                <HiArrowRight className="w-4 h-4 rotate-180" />
-                                <span>Back</span>
-                            </Link>
+                                >
+                                    <HiArrowRight className="w-4 h-4 rotate-180" />
+                                    <span>Back</span>
+                                </Link>
 
-                            <div className="flex gap-2">
-                                {["all", "active", "upcoming"].map(
-                                    (filterOption) => (
-                                        <button
-                                            key={filterOption}
-                                            onClick={() =>
-                                                setFilter(filterOption)
-                                            }
-                                            className={`
+                                <div className="flex gap-2">
+                                    {["all", "active", "upcoming"].map(
+                                        (filterOption) => (
+                                            <button
+                                                key={filterOption}
+                                                onClick={() =>
+                                                    setFilter(filterOption)
+                                                }
+                                                className={`
                                             px-3 py-1.5 rounded-lg text-sm font-medium
                                             transition-all duration-200
                                             ${
@@ -163,246 +165,250 @@ export default function CommunitiesPage() {
                                                     : "bg-gray-100 dark:bg-gray-800/50 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-800/80 hover:text-gray-900 dark:hover:text-white"
                                             }
                                         `}
-                                        >
-                                            {filterOption
-                                                .charAt(0)
-                                                .toUpperCase() +
-                                                filterOption.slice(1)}
-                                        </button>
-                                    )
-                                )}
+                                            >
+                                                {filterOption
+                                                    .charAt(0)
+                                                    .toUpperCase() +
+                                                    filterOption.slice(1)}
+                                            </button>
+                                        )
+                                    )}
+                                </div>
                             </div>
-                        </div>
 
-                        <select
-                            value={selectedLanguage}
-                            onChange={(e) =>
-                                setSelectedLanguage(e.target.value)
-                            }
-                            className="px-3 py-1.5 bg-gray-100 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-lg
+                            <select
+                                value={selectedLanguage}
+                                onChange={(e) =>
+                                    setSelectedLanguage(e.target.value)
+                                }
+                                className="px-3 py-1.5 bg-gray-100 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-lg
                                 text-gray-900 dark:text-gray-300 focus:outline-none focus:border-orange-500/50"
-                        >
-                            {languages.map((lang) => (
-                                <option key={lang} value={lang}>
-                                    {lang.charAt(0).toUpperCase() +
-                                        lang.slice(1)}
-                                </option>
-                            ))}
-                        </select>
+                            >
+                                {languages.map((lang) => (
+                                    <option key={lang} value={lang}>
+                                        {lang.charAt(0).toUpperCase() +
+                                            lang.slice(1)}
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
                     </div>
                 </div>
-            </div>
 
-            <div className="max-w-7xl mx-auto px-4 py-6">
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                    {filteredCommunities.map((community) => (
-                        <motion.div
-                            key={community.id}
-                            initial={{ opacity: 0, y: 20 }}
-                            animate={{ opacity: 1, y: 0 }}
-                            transition={{ duration: 0.3 }}
-                        >
-                            <Link
-                                href={`/decoding/communities/${community.id}`}
-                                className="group block bg-white dark:bg-gray-800/30 hover:bg-gray-50 dark:hover:bg-gray-800/50 
+                <div className="max-w-7xl mx-auto px-4 py-6">
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                        {filteredCommunities.map((community) => (
+                            <m.div
+                                key={community.id}
+                                initial={{ opacity: 0, y: 20 }}
+                                animate={{ opacity: 1, y: 0 }}
+                                transition={{ duration: 0.3 }}
+                            >
+                                <Link
+                                    href={`/decoding/communities/${community.id}`}
+                                    className="group block bg-white dark:bg-gray-800/30 hover:bg-gray-50 dark:hover:bg-gray-800/50 
                                     rounded-xl border border-gray-200 dark:border-gray-700/50 overflow-hidden
                                     transition-all duration-300 hover:border-orange-500/20
                                     hover:shadow-lg hover:shadow-orange-500/5"
-                            >
-                                <div className="relative p-6">
-                                    <div className="absolute top-0 left-0 w-full h-full bg-gradient-to-b from-gray-100/50 dark:from-gray-700/5 to-transparent" />
-                                    <div className="relative">
-                                        <div className="flex items-start justify-between mb-6">
-                                            <div className="flex gap-4">
-                                                <div className="w-16 h-16 relative rounded-xl overflow-hidden">
-                                                    <Image
-                                                        src={community.logo}
-                                                        alt={community.name}
-                                                        fill
-                                                        className="object-cover"
-                                                    />
-                                                </div>
-                                                <div>
-                                                    <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
-                                                        {community.name}
-                                                    </h2>
-                                                    <div className="flex items-center gap-3 text-sm">
-                                                        <span
-                                                            className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusDisplay(community.currentCohort.status).classes}`}
-                                                        >
-                                                            {
-                                                                getStatusDisplay(
-                                                                    community
-                                                                        .currentCohort
-                                                                        .status
-                                                                ).text
-                                                            }
-                                                        </span>
-                                                        <span className="text-gray-600 dark:text-gray-400">
-                                                            Cohort #
-                                                            {
-                                                                community
-                                                                    .currentCohort
-                                                                    .number
-                                                            }
-                                                        </span>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <HiArrowRight
-                                                className="w-5 h-5 text-orange-500 opacity-0 group-hover:opacity-100 
-                                                transition-all duration-300 transform group-hover:translate-x-1"
-                                            />
-                                        </div>
-
-                                        <div className="grid grid-cols-2 gap-4 mb-6">
-                                            <div className="space-y-1">
-                                                <div className="text-xs text-gray-500">
-                                                    Language
-                                                </div>
-                                                <div className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
-                                                    <HiGlobe className="w-4 h-4 text-gray-500 dark:text-gray-400" />
-                                                    {community.language}
-                                                </div>
-                                            </div>
-                                            <div className="space-y-1">
-                                                <div className="text-xs text-gray-500">
-                                                    Timezone
-                                                </div>
-                                                <div className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
-                                                    <HiClock className="w-4 h-4 text-gray-500 dark:text-gray-400" />
-                                                    {community.timezone}
-                                                </div>
-                                            </div>
-                                        </div>
-
-                                        <p className="text-gray-600 dark:text-gray-400 text-sm leading-relaxed mb-6">
-                                            {community.description}
-                                        </p>
-
-                                        <div className="bg-gray-50 dark:bg-gray-900/50 rounded-xl p-4 space-y-4">
-                                            <div className="grid grid-cols-2 gap-4">
-                                                <div className="flex items-center gap-3">
-                                                    <div className="p-2 rounded-lg bg-gray-100 dark:bg-gray-800/50">
-                                                        <HiUsers className="w-4 h-4 text-orange-500 dark:text-orange-400" />
-                                                    </div>
-                                                    <div>
-                                                        <div className="text-sm font-medium text-gray-900 dark:text-white">
-                                                            {
-                                                                community
-                                                                    .currentCohort
-                                                                    .students
-                                                            }
-                                                        </div>
-                                                        <div className="text-xs text-gray-500 dark:text-gray-400">
-                                                            Students
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <div className="flex items-center gap-3">
-                                                    <div className="p-2 rounded-lg bg-gray-100 dark:bg-gray-800/50">
-                                                        <FaDiscord className="w-4 h-4 text-[#5865F2]" />
-                                                    </div>
-                                                    <div>
-                                                        <div className="text-sm font-medium text-gray-900 dark:text-white">
-                                                            {
-                                                                community.totalAlumni
-                                                            }
-                                                        </div>
-                                                        <div className="text-xs text-gray-500 dark:text-gray-400">
-                                                            Alumni
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </div>
-
-                                            {community.currentCohort.status ===
-                                                "in-progress" && (
-                                                <div className="space-y-2">
-                                                    <div className="flex items-center justify-between text-sm">
-                                                        <span className="text-gray-600 dark:text-gray-400">
-                                                            Progress
-                                                        </span>
-                                                        <span className="text-orange-600 dark:text-orange-400 font-medium">
-                                                            {
-                                                                community
-                                                                    .currentCohort
-                                                                    .progress
-                                                            }
-                                                            %
-                                                        </span>
-                                                    </div>
-                                                    <div className="w-full bg-gray-200 dark:bg-gray-800 rounded-full h-1.5 overflow-hidden">
-                                                        <motion.div
-                                                            initial={{
-                                                                width: 0
-                                                            }}
-                                                            animate={{
-                                                                width: `${community.currentCohort.progress}%`
-                                                            }}
-                                                            transition={{
-                                                                duration: 1,
-                                                                ease: "easeOut"
-                                                            }}
-                                                            className="bg-orange-500 h-full rounded-full"
+                                >
+                                    <div className="relative p-6">
+                                        <div className="absolute top-0 left-0 w-full h-full bg-gradient-to-b from-gray-100/50 dark:from-gray-700/5 to-transparent" />
+                                        <div className="relative">
+                                            <div className="flex items-start justify-between mb-6">
+                                                <div className="flex gap-4">
+                                                    <div className="w-16 h-16 relative rounded-xl overflow-hidden">
+                                                        <Image
+                                                            src={community.logo}
+                                                            alt={community.name}
+                                                            fill
+                                                            className="object-cover"
                                                         />
                                                     </div>
+                                                    <div>
+                                                        <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+                                                            {community.name}
+                                                        </h2>
+                                                        <div className="flex items-center gap-3 text-sm">
+                                                            <span
+                                                                className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusDisplay(community.currentCohort.status).classes}`}
+                                                            >
+                                                                {
+                                                                    getStatusDisplay(
+                                                                        community
+                                                                            .currentCohort
+                                                                            .status
+                                                                    ).text
+                                                                }
+                                                            </span>
+                                                            <span className="text-gray-600 dark:text-gray-400">
+                                                                Cohort #
+                                                                {
+                                                                    community
+                                                                        .currentCohort
+                                                                        .number
+                                                                }
+                                                            </span>
+                                                        </div>
+                                                    </div>
                                                 </div>
-                                            )}
-                                        </div>
-                                    </div>
-                                </div>
+                                                <HiArrowRight
+                                                    className="w-5 h-5 text-orange-500 opacity-0 group-hover:opacity-100 
+                                                transition-all duration-300 transform group-hover:translate-x-1"
+                                                />
+                                            </div>
 
-                                <div className="border-t border-gray-200 dark:border-gray-700/50 p-4 bg-gray-50 dark:bg-gray-900/30">
-                                    <div className="flex items-center justify-between">
-                                        <div className="flex items-center gap-2">
-                                            <div className="w-8 h-8 rounded-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center">
-                                                <HiClock className="w-4 h-4 text-gray-500 dark:text-gray-400" />
-                                            </div>
-                                            <div className="text-sm">
-                                                <span className="text-gray-600 dark:text-gray-400">
-                                                    {new Date(
-                                                        community.currentCohort.startDate
-                                                    ) <= new Date()
-                                                        ? "Started"
-                                                        : "Starts"}
-                                                </span>
-                                                <div className="text-gray-900 dark:text-white font-medium">
-                                                    {formatDate(
-                                                        community.currentCohort
-                                                            .startDate
-                                                    )}
+                                            <div className="grid grid-cols-2 gap-4 mb-6">
+                                                <div className="space-y-1">
+                                                    <div className="text-xs text-gray-500">
+                                                        Language
+                                                    </div>
+                                                    <div className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                                                        <HiGlobe className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+                                                        {community.language}
+                                                    </div>
+                                                </div>
+                                                <div className="space-y-1">
+                                                    <div className="text-xs text-gray-500">
+                                                        Timezone
+                                                    </div>
+                                                    <div className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                                                        <HiClock className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+                                                        {community.timezone}
+                                                    </div>
                                                 </div>
                                             </div>
+
+                                            <p className="text-gray-600 dark:text-gray-400 text-sm leading-relaxed mb-6">
+                                                {community.description}
+                                            </p>
+
+                                            <div className="bg-gray-50 dark:bg-gray-900/50 rounded-xl p-4 space-y-4">
+                                                <div className="grid grid-cols-2 gap-4">
+                                                    <div className="flex items-center gap-3">
+                                                        <div className="p-2 rounded-lg bg-gray-100 dark:bg-gray-800/50">
+                                                            <HiUsers className="w-4 h-4 text-orange-500 dark:text-orange-400" />
+                                                        </div>
+                                                        <div>
+                                                            <div className="text-sm font-medium text-gray-900 dark:text-white">
+                                                                {
+                                                                    community
+                                                                        .currentCohort
+                                                                        .students
+                                                                }
+                                                            </div>
+                                                            <div className="text-xs text-gray-500 dark:text-gray-400">
+                                                                Students
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <div className="flex items-center gap-3">
+                                                        <div className="p-2 rounded-lg bg-gray-100 dark:bg-gray-800/50">
+                                                            <FaDiscord className="w-4 h-4 text-[#5865F2]" />
+                                                        </div>
+                                                        <div>
+                                                            <div className="text-sm font-medium text-gray-900 dark:text-white">
+                                                                {
+                                                                    community.totalAlumni
+                                                                }
+                                                            </div>
+                                                            <div className="text-xs text-gray-500 dark:text-gray-400">
+                                                                Alumni
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+
+                                                {community.currentCohort
+                                                    .status ===
+                                                    "in-progress" && (
+                                                    <div className="space-y-2">
+                                                        <div className="flex items-center justify-between text-sm">
+                                                            <span className="text-gray-600 dark:text-gray-400">
+                                                                Progress
+                                                            </span>
+                                                            <span className="text-orange-600 dark:text-orange-400 font-medium">
+                                                                {
+                                                                    community
+                                                                        .currentCohort
+                                                                        .progress
+                                                                }
+                                                                %
+                                                            </span>
+                                                        </div>
+                                                        <div className="w-full bg-gray-200 dark:bg-gray-800 rounded-full h-1.5 overflow-hidden">
+                                                            <m.div
+                                                                initial={{
+                                                                    width: 0
+                                                                }}
+                                                                animate={{
+                                                                    width: `${community.currentCohort.progress}%`
+                                                                }}
+                                                                transition={{
+                                                                    duration: 1,
+                                                                    ease: "easeOut"
+                                                                }}
+                                                                className="bg-orange-500 h-full rounded-full"
+                                                            />
+                                                        </div>
+                                                    </div>
+                                                )}
+                                            </div>
                                         </div>
-                                        <span className="text-orange-600 dark:text-orange-400 font-medium group-hover:translate-x-1 transition-transform duration-300">
-                                            View Details →
-                                        </span>
                                     </div>
-                                </div>
-                            </Link>
-                        </motion.div>
-                    ))}
+
+                                    <div className="border-t border-gray-200 dark:border-gray-700/50 p-4 bg-gray-50 dark:bg-gray-900/30">
+                                        <div className="flex items-center justify-between">
+                                            <div className="flex items-center gap-2">
+                                                <div className="w-8 h-8 rounded-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center">
+                                                    <HiClock className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+                                                </div>
+                                                <div className="text-sm">
+                                                    <span className="text-gray-600 dark:text-gray-400">
+                                                        {new Date(
+                                                            community.currentCohort.startDate
+                                                        ) <= new Date()
+                                                            ? "Started"
+                                                            : "Starts"}
+                                                    </span>
+                                                    <div className="text-gray-900 dark:text-white font-medium">
+                                                        {formatDate(
+                                                            community
+                                                                .currentCohort
+                                                                .startDate
+                                                        )}
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <span className="text-orange-600 dark:text-orange-400 font-medium group-hover:translate-x-1 transition-transform duration-300">
+                                                View Details →
+                                            </span>
+                                        </div>
+                                    </div>
+                                </Link>
+                            </m.div>
+                        ))}
+                    </div>
+
+                    {filteredCommunities.length === 0 && (
+                        <m.div
+                            initial={{ opacity: 0, y: 20 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            className="text-center py-20"
+                        >
+                            <div className="w-20 h-20 mx-auto mb-6 rounded-full bg-gray-100 dark:bg-gray-800/50 flex items-center justify-center">
+                                <FaRocket className="w-8 h-8 text-gray-400 dark:text-gray-600" />
+                            </div>
+                            <h3 className="text-xl font-medium text-gray-900 dark:text-white mb-2">
+                                No communities found
+                            </h3>
+                            <p className="text-gray-600 dark:text-gray-400">
+                                Try adjusting your filters to find more
+                                communities
+                            </p>
+                        </m.div>
+                    )}
                 </div>
-
-                {filteredCommunities.length === 0 && (
-                    <motion.div
-                        initial={{ opacity: 0, y: 20 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        className="text-center py-20"
-                    >
-                        <div className="w-20 h-20 mx-auto mb-6 rounded-full bg-gray-100 dark:bg-gray-800/50 flex items-center justify-center">
-                            <FaRocket className="w-8 h-8 text-gray-400 dark:text-gray-600" />
-                        </div>
-                        <h3 className="text-xl font-medium text-gray-900 dark:text-white mb-2">
-                            No communities found
-                        </h3>
-                        <p className="text-gray-600 dark:text-gray-400">
-                            Try adjusting your filters to find more communities
-                        </p>
-                    </motion.div>
-                )}
             </div>
-        </div>
+        </LazyMotion>
     )
 }

--- a/app/decoding/layout.tsx
+++ b/app/decoding/layout.tsx
@@ -3,7 +3,8 @@
 import { ReactNode, useState, useEffect } from "react"
 import { usePathname } from "next/navigation"
 import { Navigation } from "@/components/decoding-bitcoin/Navigation"
-import { motion, AnimatePresence } from "framer-motion"
+import * as m from "framer-motion/m"
+import { LazyMotion, domAnimation, AnimatePresence } from "framer-motion"
 import { MoreVertical } from "lucide-react"
 import Link from "next/link"
 import React from "react"
@@ -62,99 +63,101 @@ export default function DecodingLayout({ children }: { children: ReactNode }) {
     }
 
     return (
-        <div className="flex w-full flex-col bg-vscode-background-light dark:bg-vscode-background-dark">
-            {/* Mobile */}
-            <div className="lg:hidden w-full">
-                <div className="">
-                    {/* File Tree and Navigation Toggle */}
-                    <div
-                        className={`fixed left-0 right-0 z-20 flex items-center border-b border-gray-200 dark:border-gray-700 px-4 py-2 transition-all duration-300 ${
-                            isScrolled
-                                ? "bg-white/0 dark:bg-gray-900/0 backdrop-blur-md"
-                                : "bg-transparent"
-                        }`}
-                    >
-                        <button
-                            onClick={toggleNav}
-                            className="p-2 rounded-md text-gray-600 dark:text-gray-300 backdrop-blur-sm"
+        <LazyMotion features={domAnimation}>
+            <div className="flex w-full flex-col bg-vscode-background-light dark:bg-vscode-background-dark">
+                {/* Mobile */}
+                <div className="lg:hidden w-full">
+                    <div className="">
+                        {/* File Tree and Navigation Toggle */}
+                        <div
+                            className={`fixed left-0 right-0 z-20 flex items-center border-b border-gray-200 dark:border-gray-700 px-4 py-2 transition-all duration-300 ${
+                                isScrolled
+                                    ? "bg-white/0 dark:bg-gray-900/0 backdrop-blur-md"
+                                    : "bg-transparent"
+                            }`}
                         >
-                            <MoreVertical size={20} />
-                        </button>
-                        <div className="flex-1 overflow-x-auto">
-                            <div className="flex items-center text-sm text-gray-600 dark:text-gray-300 whitespace-nowrap">
-                                {currentPath.map((part, index) => (
-                                    <React.Fragment key={index}>
-                                        {index > 0 && (
-                                            <span className="mx-1">/</span>
-                                        )}
-                                        <Link
-                                            href={`/${currentPath
-                                                .slice(0, index + 1)
-                                                .join("/")}`}
-                                            className="hover:text-orange-500"
-                                        >
-                                            {part}
-                                        </Link>
-                                    </React.Fragment>
-                                ))}
+                            <button
+                                onClick={toggleNav}
+                                className="p-2 rounded-md text-gray-600 dark:text-gray-300 backdrop-blur-sm"
+                            >
+                                <MoreVertical size={20} />
+                            </button>
+                            <div className="flex-1 overflow-x-auto">
+                                <div className="flex items-center text-sm text-gray-600 dark:text-gray-300 whitespace-nowrap">
+                                    {currentPath.map((part, index) => (
+                                        <React.Fragment key={index}>
+                                            {index > 0 && (
+                                                <span className="mx-1">/</span>
+                                            )}
+                                            <Link
+                                                href={`/${currentPath
+                                                    .slice(0, index + 1)
+                                                    .join("/")}`}
+                                                className="hover:text-orange-500"
+                                            >
+                                                {part}
+                                            </Link>
+                                        </React.Fragment>
+                                    ))}
+                                </div>
                             </div>
                         </div>
+
+                        {/* Mobile Navigation Sidebar */}
+                        <AnimatePresence>
+                            {isNavOpen && (
+                                <m.div
+                                    initial={{ x: "-100%" }}
+                                    animate={{ x: 0 }}
+                                    exit={{ x: "-100%" }}
+                                    transition={{
+                                        type: "spring",
+                                        stiffness: 300,
+                                        damping: 30
+                                    }}
+                                    className="fixed inset-0 z-[50]"
+                                >
+                                    <div
+                                        className="absolute inset-0 bg-black bg-opacity-50"
+                                        onClick={toggleNav}
+                                    />
+                                    <div className="absolute left-0 top-0 bottom-0 w-72 bg-white dark:bg-gray-900 overflow-y-auto">
+                                        <div className="py-4 px-4">
+                                            <Navigation
+                                                onLinkClick={toggleNav}
+                                                className="space-y-4"
+                                            />
+                                        </div>
+                                    </div>
+                                </m.div>
+                            )}
+                        </AnimatePresence>
                     </div>
 
-                    {/* Mobile Navigation Sidebar */}
-                    <AnimatePresence>
-                        {isNavOpen && (
-                            <motion.div
-                                initial={{ x: "-100%" }}
-                                animate={{ x: 0 }}
-                                exit={{ x: "-100%" }}
-                                transition={{
-                                    type: "spring",
-                                    stiffness: 300,
-                                    damping: 30
-                                }}
-                                className="fixed inset-0 z-[50]"
-                            >
-                                <div
-                                    className="absolute inset-0 bg-black bg-opacity-50"
-                                    onClick={toggleNav}
-                                />
-                                <div className="absolute left-0 top-0 bottom-0 w-72 bg-white dark:bg-gray-900 overflow-y-auto">
-                                    <div className="py-4 px-4">
-                                        <Navigation
-                                            onLinkClick={toggleNav}
-                                            className="space-y-4"
-                                        />
-                                    </div>
-                                </div>
-                            </motion.div>
-                        )}
-                    </AnimatePresence>
+                    {/* Mobile Main Content */}
+                    <div className="">{children}</div>
                 </div>
 
-                {/* Mobile Main Content */}
-                <div className="">{children}</div>
-            </div>
+                {/* Desktop */}
+                <div className="hidden lg:relative lg:block">
+                    <div className="relative mx-auto flex w-full max-w-9xl flex-auto justify-center sm:pl-2 lg:pl-8 xl:pl-12">
+                        {/* Desktop Navigation — persistent across route changes */}
+                        <div className="lg:relative lg:flex-none border-r border-orange">
+                            {isInsideTopic && (
+                                <div className="absolute inset-y-0 right-0 w-[50vw] dark:bg-vscode-navigation-dark bg-vscode-navigation-light" />
+                            )}
+                            <div className="sticky top-[4.75rem] -ml-0.5 h-[calc(100vh-4.75rem)] w-64 overflow-y-auto overflow-x-hidden py-16 pl-0.5 pr-4 xl:w-72 xl:pr-8">
+                                <Navigation />
+                            </div>
+                        </div>
 
-            {/* Desktop */}
-            <div className="hidden lg:relative lg:block">
-                <div className="relative mx-auto flex w-full max-w-9xl flex-auto justify-center sm:pl-2 lg:pl-8 xl:pl-12">
-                    {/* Desktop Navigation — persistent across route changes */}
-                    <div className="lg:relative lg:flex-none border-r border-orange">
-                        {isInsideTopic && (
-                            <div className="absolute inset-y-0 right-0 w-[50vw] dark:bg-vscode-navigation-dark bg-vscode-navigation-light" />
-                        )}
-                        <div className="sticky top-[4.75rem] -ml-0.5 h-[calc(100vh-4.75rem)] w-64 overflow-y-auto overflow-x-hidden py-16 pl-0.5 pr-4 xl:w-72 xl:pr-8">
-                            <Navigation />
+                        {/* Desktop Main Content — only this slot updates on navigation */}
+                        <div className="min-w-0 max-w-3xl flex-auto pb-16 lg:mx-auto lg:max-w-none lg:pr-0">
+                            {children}
                         </div>
                     </div>
-
-                    {/* Desktop Main Content — only this slot updates on navigation */}
-                    <div className="min-w-0 max-w-3xl flex-auto pb-16 lg:mx-auto lg:max-w-none lg:pr-0">
-                        {children}
-                    </div>
                 </div>
             </div>
-        </div>
+        </LazyMotion>
     )
 }

--- a/components/brand/Testimonial.tsx
+++ b/components/brand/Testimonial.tsx
@@ -1,4 +1,3 @@
-import { number } from "bitcoinjs-lib/src/script"
 import clsx from "clsx"
 import Image from "next/image"
 import React, { use } from "react"

--- a/components/communities/CircularProgress.tsx
+++ b/components/communities/CircularProgress.tsx
@@ -1,4 +1,4 @@
-import { motion } from "framer-motion"
+import * as m from "framer-motion/m"
 
 interface CircularProgressProps {
     progress: number
@@ -35,7 +35,7 @@ export const CircularProgress = ({
                     stroke={secondaryColor}
                     strokeWidth={strokeWidth}
                 />
-                <motion.circle
+                <m.circle
                     cx={center}
                     cy={center}
                     r={radius}

--- a/components/communities/DashboardTabs.tsx
+++ b/components/communities/DashboardTabs.tsx
@@ -1,15 +1,31 @@
-import { motion } from "framer-motion"
+import dynamic from "next/dynamic"
+import * as m from "framer-motion/m"
+import { LazyMotion, domAnimation } from "framer-motion"
 import {
     collectQuestions,
     Community,
     WeeklyData
 } from "@/lib/utils/communities"
-import { QuestionsSection } from "./QuestionsSection"
-import { GroupsSection } from "./GroupsSection"
-import { AdditionalResources } from "./AdditionalResources"
 import { FaBook } from "react-icons/fa"
 import { HiDocument, HiUserCircle, HiDownload } from "react-icons/hi"
-import { LearningResourcesSection } from "./LearningResourcesSection"
+
+// lazy load components
+const QuestionsSection = dynamic(() =>
+    import("./QuestionsSection").then((m) => ({ default: m.QuestionsSection }))
+)
+const GroupsSection = dynamic(() =>
+    import("./GroupsSection").then((m) => ({ default: m.GroupsSection }))
+)
+const AdditionalResources = dynamic(() =>
+    import("./AdditionalResources").then((m) => ({
+        default: m.AdditionalResources
+    }))
+)
+const LearningResourcesSection = dynamic(() =>
+    import("./LearningResourcesSection").then((m) => ({
+        default: m.LearningResourcesSection
+    }))
+)
 
 export const DashboardTabs = ({
     activeTab,
@@ -50,15 +66,16 @@ export const DashboardTabs = ({
     ]
 
     return (
-        <div className="space-y-8">
-            {/* Enhanced Tab Navigation */}
-            <div className="border-b-2 border-gray-200 dark:border-gray-800">
-                <div className="flex">
-                    {tabs.map((tab) => (
-                        <button
-                            key={tab.id}
-                            onClick={() => setActiveTab(tab.id)}
-                            className={`
+        <LazyMotion features={domAnimation}>
+            <div className="space-y-8">
+                {/* Enhanced Tab Navigation */}
+                <div className="border-b-2 border-gray-200 dark:border-gray-800">
+                    <div className="flex">
+                        {tabs.map((tab) => (
+                            <button
+                                key={tab.id}
+                                onClick={() => setActiveTab(tab.id)}
+                                className={`
                                 flex items-center gap-2.5 px-6 py-4
                                 text-sm font-semibold relative
                                 ${
@@ -68,65 +85,66 @@ export const DashboardTabs = ({
                                 }
                                 transition-colors duration-150
                             `}
-                        >
-                            {tab.icon}
-                            <span className="tracking-wide">{tab.id}</span>
-                            {activeTab === tab.id && (
-                                <motion.div
-                                    layoutId="activeTab"
-                                    className="absolute bottom-0 left-0 right-0 h-0.5 bg-orange-500 dark:bg-orange-400"
-                                    style={{ height: "2px" }}
-                                    initial={false}
-                                />
-                            )}
-                        </button>
-                    ))}
+                            >
+                                {tab.icon}
+                                <span className="tracking-wide">{tab.id}</span>
+                                {activeTab === tab.id && (
+                                    <m.div
+                                        layoutId="activeTab"
+                                        className="absolute bottom-0 left-0 right-0 h-0.5 bg-orange-500 dark:bg-orange-400"
+                                        style={{ height: "2px" }}
+                                        initial={false}
+                                    />
+                                )}
+                            </button>
+                        ))}
+                    </div>
                 </div>
-            </div>
 
-            {/* Tab Content */}
-            <motion.div
-                className="min-h-[600px]"
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.3 }}
-            >
-                {activeTab === "Learning Path" && (
-                    <LearningResourcesSection
-                        resources={resources}
-                        weekNumber={weekNumber}
-                        totalWeeks={totalWeeks}
-                        currentWeekData={currentWeekData}
-                        currentWeek={currentWeek}
-                    />
-                )}
-
-                {activeTab === "Discussions" && (
-                    <div className="bg-white dark:bg-gray-800/40 rounded-2xl p-6 border border-gray-200 dark:border-gray-800">
-                        <QuestionsSection
-                            questions={collectQuestions(currentWeekData)}
+                {/* Tab Content */}
+                <m.div
+                    className="min-h-[600px]"
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.3 }}
+                >
+                    {activeTab === "Learning Path" && (
+                        <LearningResourcesSection
+                            resources={resources}
                             weekNumber={weekNumber}
-                        />
-                    </div>
-                )}
-
-                {activeTab === "Groups" && (
-                    <div className="bg-white dark:bg-gray-800/40 rounded-2xl p-6 border border-gray-200 dark:border-gray-800">
-                        <GroupsSection
-                            weekData={currentWeekData}
-                            weekNumber={weekNumber}
+                            totalWeeks={totalWeeks}
+                            currentWeekData={currentWeekData}
                             currentWeek={currentWeek}
-                            communityData={communityData}
                         />
-                    </div>
-                )}
+                    )}
 
-                {activeTab === "Resources" && (
-                    <div className="bg-white dark:bg-gray-800/40 rounded-2xl p-6 border border-gray-200 dark:border-gray-800">
-                        <AdditionalResources weekData={currentWeekData} />
-                    </div>
-                )}
-            </motion.div>
-        </div>
+                    {activeTab === "Discussions" && (
+                        <div className="bg-white dark:bg-gray-800/40 rounded-2xl p-6 border border-gray-200 dark:border-gray-800">
+                            <QuestionsSection
+                                questions={collectQuestions(currentWeekData)}
+                                weekNumber={weekNumber}
+                            />
+                        </div>
+                    )}
+
+                    {activeTab === "Groups" && (
+                        <div className="bg-white dark:bg-gray-800/40 rounded-2xl p-6 border border-gray-200 dark:border-gray-800">
+                            <GroupsSection
+                                weekData={currentWeekData}
+                                weekNumber={weekNumber}
+                                currentWeek={currentWeek}
+                                communityData={communityData}
+                            />
+                        </div>
+                    )}
+
+                    {activeTab === "Resources" && (
+                        <div className="bg-white dark:bg-gray-800/40 rounded-2xl p-6 border border-gray-200 dark:border-gray-800">
+                            <AdditionalResources weekData={currentWeekData} />
+                        </div>
+                    )}
+                </m.div>
+            </div>
+        </LazyMotion>
     )
 }

--- a/components/decoding-bitcoin/Navigation.tsx
+++ b/components/decoding-bitcoin/Navigation.tsx
@@ -10,9 +10,25 @@ import {
 } from "pliny/utils/contentlayer"
 import { Topic, allTopics } from "@/.contentlayer/generated"
 import { useState, useEffect, useCallback, useMemo } from "react"
-import { motion } from "framer-motion"
-import { FaChevronRight, FaChevronDown, FaCheck } from "react-icons/fa"
-import * as Icons from "react-icons/fa"
+import * as m from "framer-motion/m"
+import {
+    FaCheck,
+    FaChevronDown,
+    FaChevronRight,
+    FaClipboardList,
+    FaDiscord,
+    FaFileCode,
+    FaFileSignature,
+    FaHandshake,
+    FaHashtag,
+    FaHistory,
+    FaKey,
+    FaLightbulb,
+    FaQuestionCircle,
+    FaRoute,
+    FaTools,
+    FaUsers
+} from "react-icons/fa"
 import { ArrowRight } from "lucide-react"
 
 interface NavigationLink {
@@ -42,6 +58,20 @@ const categoryOrder = [
     "References",
     "Contribution"
 ]
+
+const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
+    FaClipboardList,
+    FaDiscord,
+    FaFileCode,
+    FaFileSignature,
+    FaHandshake,
+    FaHashtag,
+    FaHistory,
+    FaKey,
+    FaRoute,
+    FaTools,
+    FaUsers
+}
 
 export function Navigation({
     className,
@@ -228,8 +258,7 @@ export function Navigation({
     }, [pathname, navigation])
 
     const getIcon = useCallback((iconName: string) => {
-        const IconComponent =
-            Icons[iconName as keyof typeof Icons] || Icons.FaQuestionCircle
+        const IconComponent = iconMap[iconName] ?? FaQuestionCircle
         return <IconComponent className="inline-block mr-2 text-current" />
     }, [])
 
@@ -275,7 +304,7 @@ export function Navigation({
                 >
                     <div className="flex items-center flex-1 min-w-0">
                         <div className="flex-shrink-0 w-8 h-8 flex items-center justify-center rounded-lg bg-orange-500/20 mr-3">
-                            <Icons.FaUsers className="w-4 h-4 text-orange-500" />
+                            <FaUsers className="w-4 h-4 text-orange-500" />
                         </div>
                         <div>
                             <h3 className="text-sm font-semibold text-orange-500 dark:text-orange-400">
@@ -305,7 +334,7 @@ export function Navigation({
                 >
                     <div className="flex items-center flex-1 min-w-0">
                         <div className="flex-shrink-0 w-8 h-8 flex items-center justify-center rounded-lg bg-purple-500/20 mr-3">
-                            <Icons.FaLightbulb className="w-4 h-4 text-purple-500" />
+                            <FaLightbulb className="w-4 h-4 text-purple-500" />
                         </div>
                         <div>
                             <h3 className="text-sm font-semibold text-purple-500 dark:text-purple-400">
@@ -540,7 +569,7 @@ const EmailSubscription = () => {
                     className="flex-grow px-3 py-1 text-sm bg-transparent border-b border-gray-300 focus:border-orange-500 focus:outline-none dark:border-gray-700 dark:text-gray-300"
                     required
                 />
-                <motion.button
+                <m.button
                     type="submit"
                     className="ml-2 px-3 py-1 text-sm font-medium text-orange-500 hover:text-orange-600 focus:outline-none"
                     whileHover={{ scale: 1.05 }}
@@ -548,7 +577,7 @@ const EmailSubscription = () => {
                     disabled={loading}
                 >
                     {loading ? "Subscribing..." : "Subscribe"}
-                </motion.button>
+                </m.button>
             </form>
             {mailchimpResponse && (
                 <p className="mt-2 text-sm text-green-500">

--- a/components/decoding-bitcoin/hero/Hero.tsx
+++ b/components/decoding-bitcoin/hero/Hero.tsx
@@ -12,7 +12,7 @@ import {
 import { allCoreContent, sortPosts } from "pliny/utils/contentlayer"
 import { allTopics } from "@/.contentlayer/generated"
 import { FaDiscord } from "react-icons/fa"
-import { motion } from "framer-motion"
+import * as m from "framer-motion/m"
 
 import { Button } from "./Button"
 import blurOrangeImage from "@/public/images/topics-hero/blur-orange.webp"
@@ -227,7 +227,7 @@ const ContinueReadingComp: React.FC<{
                         </div>
 
                         {/* Improved Discord card */}
-                        <motion.a
+                        <m.a
                             href="https://discord.gg/EAy9XMufbY"
                             target="_blank"
                             rel="noopener noreferrer"
@@ -239,7 +239,7 @@ const ContinueReadingComp: React.FC<{
                             <div className="absolute inset-0 bg-gradient-to-r from-indigo-400 to-indigo-600 rounded-xl opacity-10 blur-lg"></div>
                             <div className="relative bg-white/45 dark:bg-gray-800/45 rounded-xl p-6 transition-all duration-300 group-hover:bg-indigo-50/90 dark:group-hover:bg-indigo-900/30">
                                 <div className="flex items-center space-x-3 mb-3">
-                                    <motion.div
+                                    <m.div
                                         animate={{
                                             y: isHovered ? -5 : 0,
                                             rotate: isHovered ? -10 : 0
@@ -254,7 +254,7 @@ const ContinueReadingComp: React.FC<{
                                             size={30}
                                             className="text-indigo-500 dark:text-indigo-400"
                                         />
-                                    </motion.div>
+                                    </m.div>
                                     <h2 className="text-xl font-semibold text-gray-900 dark:text-white group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors duration-300">
                                         Join our Community
                                     </h2>
@@ -263,7 +263,7 @@ const ContinueReadingComp: React.FC<{
                                     Connect with fellow Bitcoin enthusiasts, get
                                     support, and stay updated.
                                 </p>
-                                <motion.div
+                                <m.div
                                     className="absolute bottom-4 right-4 opacity-0 group-hover:opacity-100 transition-opacity duration-300"
                                     animate={{ x: isHovered ? [0, 10, 0] : 0 }}
                                     transition={{
@@ -273,9 +273,9 @@ const ContinueReadingComp: React.FC<{
                                     }}
                                 >
                                     <ArrowRightIcon className="h-6 w-6 text-indigo-500 dark:text-indigo-400" />
-                                </motion.div>
+                                </m.div>
                             </div>
-                        </motion.a>
+                        </m.a>
                     </div>
                 </div>
             </div>

--- a/components/decoding-bitcoin/layouts/BaseLayout.tsx
+++ b/components/decoding-bitcoin/layouts/BaseLayout.tsx
@@ -10,8 +10,8 @@ import { TopicHeader } from "../topic/TopicHeader"
 import { usePathname } from "next/navigation"
 import Image from "next/image"
 import Link from "next/link"
-
-import { motion, AnimatePresence } from "framer-motion"
+import * as m from "framer-motion/m"
+import { AnimatePresence } from "framer-motion"
 import { CheckCircle, Loader2, ArrowRight } from "lucide-react"
 import React from "react"
 import { GitHubIcon } from "@/public/images/topics-hero/GitHubIcon"
@@ -104,7 +104,7 @@ export default function BaseLayout({
 
     const ActionButtons = () => (
         <div className="flex items-center justify-between w-full max-w-3xl mx-auto">
-            <motion.a
+            <m.a
                 href={githubEditUrl}
                 target="_blank"
                 rel="noopener noreferrer"
@@ -114,18 +114,18 @@ export default function BaseLayout({
             >
                 <GitHubIcon className="w-4 h-4 mr-2" />
                 Suggest Edits
-            </motion.a>
+            </m.a>
             <div className="flex items-center gap-4">
                 <AnimatePresence mode="wait">
                     {isCompleted ? (
-                        <motion.div
+                        <m.div
                             className="flex items-center gap-4"
                             initial={{ opacity: 0, x: -20 }}
                             animate={{ opacity: 1, x: 0 }}
                             exit={{ opacity: 0, x: 20 }}
                             transition={{ duration: 0.3 }}
                         >
-                            <motion.button
+                            <m.button
                                 onClick={toggleCompleted}
                                 className="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-orange-500 rounded-md hover:bg-orange-600 transition-colors"
                                 whileHover={{ scale: 1.02 }}
@@ -133,29 +133,29 @@ export default function BaseLayout({
                             >
                                 <CheckCircle className="w-4 h-4 mr-2" />
                                 Completed
-                            </motion.button>
+                            </m.button>
 
                             {next?.path && (
-                                <motion.div
+                                <m.div
                                     initial={{ opacity: 0, x: 20 }}
                                     animate={{ opacity: 1, x: 0 }}
                                     transition={{ delay: 0.2 }}
                                 >
                                     <Link href={`/${next.path}`}>
-                                        <motion.button
+                                        <m.button
                                             className="inline-flex items-center px-4 py-2 text-sm font-medium border-2 border-orange-500 text-orange-500 hover:bg-orange-50 dark:hover:bg-orange-500/10 rounded-md transition-colors"
                                             whileHover={{ scale: 1.02 }}
                                             whileTap={{ scale: 0.98 }}
                                         >
                                             Next Topic
                                             <ArrowRight className="w-4 h-4 ml-2" />
-                                        </motion.button>
+                                        </m.button>
                                     </Link>
-                                </motion.div>
+                                </m.div>
                             )}
-                        </motion.div>
+                        </m.div>
                     ) : (
-                        <motion.button
+                        <m.button
                             onClick={toggleCompleted}
                             className="inline-flex items-center px-4 py-2 text-sm font-medium text-orange-500 border-2 border-orange-500 rounded-md hover:bg-orange-50 dark:hover:bg-orange-500/10 transition-colors"
                             whileHover={{ scale: 1.02 }}
@@ -173,7 +173,7 @@ export default function BaseLayout({
                             {isLoading
                                 ? "Marking as Complete..."
                                 : "Mark as Complete"}
-                        </motion.button>
+                        </m.button>
                     )}
                 </AnimatePresence>
             </div>

--- a/components/decoding-bitcoin/markdown-ui/MDXComponents.tsx
+++ b/components/decoding-bitcoin/markdown-ui/MDXComponents.tsx
@@ -1,36 +1,61 @@
+import dynamic from "next/dynamic"
 import TOCInline from "pliny/ui/TOCInline"
 import BlogNewsletterForm from "pliny/ui/BlogNewsletterForm"
 import type { MDXComponents } from "mdx/types"
 import CustomLink from "./Link"
 import Image from "./Image"
 import SvgDisplay from "./script-visualizer/SvgDisplay"
-import ScriptStackVisualizer from "./script-visualizer/scriptVisualizer"
-import TransactionsDisplay from "./transaction-serializer/TransactionDisplay"
-import { QuickLink, QuickLinks } from "./QuickLinks"
-import Hint from "./Hints"
-import MinimalVideoPlayer from "./minimal-video-player"
-import ExpandableAlert from "./expandable-alert"
-import P2SHEncoder from "./address-encoder"
-import OpcodeDataVisualizer from "./opcode-data-visualizer"
-import OpCodeExplorer from "./opcode-explorer"
-import MultisigAnimation from "./multisig-animation"
-import SandpackComponent from "./sandpack"
-import Quiz from "./Quiz"
-import StackSimulator from "./stack-simulator"
-import { CodeSnippet } from "./code-snippet"
-import ExerciseSelector from "./exercise-selector"
-import MailingListSignup from "./mailing-list-signup"
-import { BitcoinHistory } from "./bitcoin-history"
-import HexTransactionHighlighter from "./hex-transaction-highlighter"
-import DiscordInvite from "./discord-invite"
-import TransactionCreation from "@/src/components/TransactionCreation"
-import TransactionAnimationPlayer from "@/content/transaction-animation-player"
-import TransactionDecoder from "./transaction-decoder"
-import ReorgCalculator from "./reorg-calculator"
-import HashFunctions from "./hash-functions"
-import AddressGenerator from "./address-generator"
-import { ByteTools } from "./byte-tools"
-import InteractiveRoadmap from "../roadmap/InteractiveRoadmap"
+
+const ScriptStackVisualizer = dynamic(
+    () => import("./script-visualizer/scriptVisualizer")
+)
+const TransactionsDisplay = dynamic(
+    () => import("./transaction-serializer/TransactionDisplay")
+)
+const QuickLinks = dynamic(() =>
+    import("./QuickLinks").then((m) => ({ default: m.QuickLinks }))
+)
+const QuickLink = dynamic(() =>
+    import("./QuickLinks").then((m) => ({ default: m.QuickLink }))
+)
+const Hint = dynamic(() => import("./Hints"))
+const MinimalVideoPlayer = dynamic(() => import("./minimal-video-player"))
+const ExpandableAlert = dynamic(() => import("./expandable-alert"))
+const P2SHEncoder = dynamic(() => import("./address-encoder"))
+const OpcodeDataVisualizer = dynamic(() => import("./opcode-data-visualizer"))
+const OpCodeExplorer = dynamic(() => import("./opcode-explorer"))
+const MultisigAnimation = dynamic(() => import("./multisig-animation"))
+const SandpackComponent = dynamic(() => import("./sandpack"), { ssr: false })
+const Quiz = dynamic(() => import("./Quiz"))
+const StackSimulator = dynamic(() => import("./stack-simulator"))
+const CodeSnippet = dynamic(() => import("./code-snippet"))
+const ExerciseSelector = dynamic(() => import("./exercise-selector"), {
+    ssr: false
+})
+const MailingListSignup = dynamic(() => import("./mailing-list-signup"))
+const BitcoinHistory = dynamic(() =>
+    import("./bitcoin-history").then((m) => ({ default: m.BitcoinHistory }))
+)
+const HexTransactionHighlighter = dynamic(
+    () => import("./hex-transaction-highlighter")
+)
+const DiscordInvite = dynamic(() => import("./discord-invite"))
+const TransactionCreation = dynamic(
+    () => import("@/src/components/TransactionCreation")
+)
+const TransactionAnimationPlayer = dynamic(
+    () => import("@/content/transaction-animation-player")
+)
+const TransactionDecoder = dynamic(() => import("./transaction-decoder"))
+const ReorgCalculator = dynamic(() => import("./reorg-calculator"))
+const HashFunctions = dynamic(() => import("./hash-functions"))
+const AddressGenerator = dynamic(() => import("./address-generator"))
+const ByteTools = dynamic(() =>
+    import("./byte-tools").then((m) => ({ default: m.ByteTools }))
+)
+const InteractiveRoadmap = dynamic(
+    () => import("../roadmap/InteractiveRoadmap")
+)
 
 export const components: MDXComponents = {
     Image,

--- a/components/decoding-bitcoin/markdown-ui/Quiz.tsx
+++ b/components/decoding-bitcoin/markdown-ui/Quiz.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import React, { useState } from "react"
-import { motion, AnimatePresence } from "framer-motion"
+import * as m from "framer-motion/m"
+import { AnimatePresence } from "framer-motion"
 import {
     ArrowRight,
     CheckCircle,
@@ -120,7 +121,7 @@ const Quiz = ({
                     <div className="space-y-2 mb-4">
                         {questions[currentQuestion].options.map(
                             (option, index) => (
-                                <motion.button
+                                <m.button
                                     key={index}
                                     onClick={() => handleAnswerClick(option)}
                                     disabled={showExplanation}
@@ -148,7 +149,7 @@ const Quiz = ({
                                         damping: 17
                                     }}
                                 >
-                                    <motion.span
+                                    <m.span
                                         className={`flex-shrink-0 w-5 h-5 rounded-full flex items-center justify-center text-xs
                               border-2 ${
                                   selectedAnswer === option && !showExplanation
@@ -172,14 +173,14 @@ const Quiz = ({
                               }`}
                                     >
                                         {index + 1}
-                                    </motion.span>
+                                    </m.span>
                                     <span className="flex-grow">{option}</span>
                                     <AnimatePresence>
                                         {showExplanation &&
                                             option ===
                                                 questions[currentQuestion]
                                                     .correctAnswer && (
-                                                <motion.div
+                                                <m.div
                                                     initial={{
                                                         opacity: 0,
                                                         scale: 0
@@ -197,10 +198,10 @@ const Quiz = ({
                                                         className="text-vscode-success-light dark:text-vscode-success-dark"
                                                         size={20}
                                                     />
-                                                </motion.div>
+                                                </m.div>
                                             )}
                                     </AnimatePresence>
-                                </motion.button>
+                                </m.button>
                             )
                         )}
                     </div>
@@ -232,7 +233,7 @@ const Quiz = ({
 
                     <AnimatePresence>
                         {showExplanation && (
-                            <motion.div
+                            <m.div
                                 className={`mt-4 p-3 rounded-lg text-sm ${
                                     isCorrect
                                         ? "bg-vscode-success-light dark:bg-vscode-success-dark text-vscode-text-light dark:text-vscode-text-dark"
@@ -260,12 +261,12 @@ const Quiz = ({
                                     </span>
                                 </div>
                                 <p>{questions[currentQuestion].explanation}</p>
-                            </motion.div>
+                            </m.div>
                         )}
                     </AnimatePresence>
                 </>
             ) : (
-                <motion.div
+                <m.div
                     className="mt-4 p-5 rounded-lg bg-vscode-background-light dark:bg-vscode-background-dark text-vscode-text-light dark:text-vscode-text-dark"
                     initial={{ opacity: 0, y: 20 }}
                     animate={{ opacity: 1, y: 0 }}
@@ -300,7 +301,7 @@ const Quiz = ({
                             RESET QUIZ
                         </Button>
                     </div>
-                </motion.div>
+                </m.div>
             )}
         </div>
     )

--- a/components/decoding-bitcoin/markdown-ui/address-encoder.tsx
+++ b/components/decoding-bitcoin/markdown-ui/address-encoder.tsx
@@ -4,7 +4,8 @@ import React, { useState, useEffect, useCallback } from "react"
 import * as bitcoin from "bitcoinjs-lib"
 import bs58 from "bs58"
 import { ArrowsRightLeftIcon } from "@heroicons/react/24/solid"
-import { AnimatePresence, motion } from "framer-motion"
+import * as m from "framer-motion/m"
+import { AnimatePresence } from "framer-motion"
 
 interface P2SHEncoderProps {
     initialScriptHash?: string
@@ -133,7 +134,7 @@ const P2SHEncoder: React.FC<P2SHEncoderProps> = ({
                                     />
                                     <AnimatePresence>
                                         {isAnimating && (
-                                            <motion.button
+                                            <m.button
                                                 key="animating-button"
                                                 onClick={
                                                     handleGenerateRandomScriptHash
@@ -143,10 +144,10 @@ const P2SHEncoder: React.FC<P2SHEncoderProps> = ({
                                                 exit={{ opacity: 1 }}
                                             >
                                                 <ArrowsRightLeftIcon className="h-5 w-5" />
-                                            </motion.button>
+                                            </m.button>
                                         )}
                                         {!isAnimating && (
-                                            <motion.button
+                                            <m.button
                                                 key="static-button"
                                                 onClick={
                                                     handleGenerateRandomScriptHash
@@ -155,7 +156,7 @@ const P2SHEncoder: React.FC<P2SHEncoderProps> = ({
                                                 initial={{ opacity: 1 }}
                                             >
                                                 <ArrowsRightLeftIcon className="h-5 w-5" />
-                                            </motion.button>
+                                            </m.button>
                                         )}
                                     </AnimatePresence>
                                 </div>

--- a/components/decoding-bitcoin/markdown-ui/address-generator.tsx
+++ b/components/decoding-bitcoin/markdown-ui/address-generator.tsx
@@ -3,7 +3,8 @@ import { useState, useCallback, useEffect } from "react"
 import * as bitcoin from "bitcoinjs-lib"
 import clsx from "clsx"
 import { Copy, Check, RefreshCw, Hash, Info, ArrowRight } from "lucide-react"
-import { motion, AnimatePresence } from "framer-motion"
+import * as m from "framer-motion/m"
+import { AnimatePresence } from "framer-motion"
 import bs58 from "bs58"
 
 // Define network types
@@ -337,7 +338,7 @@ const AddressGenerator = () => {
             {/* Simplified Information Panel */}
             <AnimatePresence>
                 {showInfo && (
-                    <motion.div
+                    <m.div
                         initial={{ opacity: 0, height: 0 }}
                         animate={{ opacity: 1, height: "auto" }}
                         exit={{ opacity: 0, height: 0 }}
@@ -364,7 +365,7 @@ const AddressGenerator = () => {
                                 </div>
                             </div>
                         </div>
-                    </motion.div>
+                    </m.div>
                 )}
             </AnimatePresence>
 

--- a/components/decoding-bitcoin/markdown-ui/bitcoin-history.tsx
+++ b/components/decoding-bitcoin/markdown-ui/bitcoin-history.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import React, { useState, useEffect } from "react"
-import { motion, useAnimation } from "framer-motion"
+import * as m from "framer-motion/m"
+import { useAnimation } from "framer-motion"
 import { useInView } from "react-intersection-observer"
 import Image from "next/image"
 import { ExternalLinkIcon } from "lucide-react"
@@ -58,7 +59,7 @@ export const BitcoinHistory: React.FC<BitcoinHistoryProps> = ({
 }) => {
     return (
         <div className="container mx-auto px-4 py-8 bg-vscode-background-light dark:bg-vscode-background-dark text-vscode-text-light dark:text-vscode-text-dark">
-            <motion.div
+            <m.div
                 className="relative mb-24 text-center"
                 initial={{ opacity: 0, y: -20 }}
                 animate={{ opacity: 1, y: 0 }}
@@ -93,7 +94,7 @@ export const BitcoinHistory: React.FC<BitcoinHistoryProps> = ({
                         height={100}
                     />
                 </div>
-            </motion.div>
+            </m.div>
             <div className="relative space-y-12 md:space-y-16">
                 {historyEvents.map((event, index) => (
                     <React.Fragment key={event.id}>
@@ -105,7 +106,7 @@ export const BitcoinHistory: React.FC<BitcoinHistoryProps> = ({
                 ))}
             </div>
 
-            <motion.div
+            <m.div
                 className="mt-32 text-center opacity-70 text-sm"
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 0.7, y: 0 }}
@@ -121,7 +122,7 @@ export const BitcoinHistory: React.FC<BitcoinHistoryProps> = ({
                     0xb10c
                     <ExternalLinkIcon size={14} className="ml-1" />
                 </a>
-            </motion.div>
+            </m.div>
         </div>
     )
 }
@@ -220,7 +221,7 @@ const EventItem: React.FC<{ event: HistoryEvent; index: number }> = ({
             case "image":
             case "gif":
                 return (
-                    <motion.div
+                    <m.div
                         initial="hidden"
                         animate={imageControls}
                         variants={imageVariants}
@@ -232,11 +233,11 @@ const EventItem: React.FC<{ event: HistoryEvent; index: number }> = ({
                             height={200}
                             className="rounded-lg mx-auto md:mx-0"
                         />
-                    </motion.div>
+                    </m.div>
                 )
             case "video":
                 return (
-                    <motion.div
+                    <m.div
                         initial="hidden"
                         animate={imageControls}
                         variants={imageVariants}
@@ -247,11 +248,11 @@ const EventItem: React.FC<{ event: HistoryEvent; index: number }> = ({
                             className="rounded-lg shadow-md mx-auto md:mx-0"
                             style={{ maxWidth: "100%", height: "auto" }}
                         />
-                    </motion.div>
+                    </m.div>
                 )
             case "svg":
                 return (
-                    <motion.div
+                    <m.div
                         initial="hidden"
                         animate={imageControls}
                         variants={imageVariants}
@@ -264,7 +265,7 @@ const EventItem: React.FC<{ event: HistoryEvent; index: number }> = ({
                             width={300}
                             height={200}
                         />
-                    </motion.div>
+                    </m.div>
                 )
             default:
                 return null
@@ -272,18 +273,18 @@ const EventItem: React.FC<{ event: HistoryEvent; index: number }> = ({
     }
 
     return (
-        <motion.div
+        <m.div
             ref={ref}
             className={`flex flex-col md:flex-row items-start mb-8 md:mb-12 ${index % 2 === 0 ? "md:flex-row" : "md:flex-row-reverse"}`}
             initial="hidden"
             animate={controls}
             variants={containerVariants}
         >
-            <motion.div
+            <m.div
                 className={`w-full md:w-7/12 ${index % 2 === 0 ? "md:text-left md:pr-8" : "md:text-right md:pl-8"} mb-6 md:mb-0`}
                 variants={childVariants}
             >
-                <motion.div
+                <m.div
                     className={`flex flex-col ${index % 2 === 0 ? "items-start" : "items-end"} mb-2`}
                     variants={childVariants}
                 >
@@ -296,23 +297,23 @@ const EventItem: React.FC<{ event: HistoryEvent; index: number }> = ({
                         </span>
                     </div>
                     <h3 className="text-2xl font-bold mb-2">{event.title}</h3>
-                </motion.div>
+                </m.div>
                 {event.paragraphs.map((paragraph, pIndex) => (
-                    <motion.p
+                    <m.p
                         key={pIndex}
                         className={`mt-3 font-extralight ${index % 2 === 0 ? "text-left" : "text-right"}`}
                         variants={childVariants}
                     >
                         {paragraph}
-                    </motion.p>
+                    </m.p>
                 ))}
                 {event.links && event.links.length > 0 && (
-                    <motion.div
+                    <m.div
                         className={`mt-4 flex flex-wrap ${index % 2 === 0 ? "justify-start" : "justify-end"} gap-2`}
                         variants={childVariants}
                     >
                         {event.links.map((link, lIndex) => (
-                            <motion.button
+                            <m.button
                                 key={lIndex}
                                 onClick={() =>
                                     window.open(
@@ -333,20 +334,20 @@ const EventItem: React.FC<{ event: HistoryEvent; index: number }> = ({
                             >
                                 {link.label}
                                 <ExternalLinkIcon size={12} className="ml-1" />
-                            </motion.button>
+                            </m.button>
                         ))}
-                    </motion.div>
+                    </m.div>
                 )}
-            </motion.div>
+            </m.div>
             {event.media && (
-                <motion.div
+                <m.div
                     className={`w-full md:w-5/12 ${index % 2 === 0 ? "md:pl-8" : "md:pr-8"}`}
                     variants={childVariants}
                 >
                     {renderMedia()}
-                </motion.div>
+                </m.div>
             )}
-        </motion.div>
+        </m.div>
     )
 }
 
@@ -365,7 +366,7 @@ const ConnectingLine: React.FC<{ index: number }> = ({ index }) => {
     }, [controls, inView])
 
     return (
-        <motion.div
+        <m.div
             className="w-full my-8 md:my-12 hidden md:block"
             ref={ref}
             initial="hidden"
@@ -393,6 +394,6 @@ const ConnectingLine: React.FC<{ index: number }> = ({ index }) => {
                     sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
                 />
             </div>
-        </motion.div>
+        </m.div>
     )
 }

--- a/components/decoding-bitcoin/markdown-ui/discord-invite.tsx
+++ b/components/decoding-bitcoin/markdown-ui/discord-invite.tsx
@@ -2,13 +2,13 @@
 
 import React, { useState } from "react"
 import { FaDiscord } from "react-icons/fa"
-import { motion } from "framer-motion"
+import * as m from "framer-motion/m"
 
 const DiscordInvite: React.FC = () => {
     const [isHovered, setIsHovered] = useState(false)
 
     return (
-        <motion.a
+        <m.a
             href="https://discord.com/invite/EAy9XMufbY"
             target="_blank"
             rel="noopener noreferrer"
@@ -17,7 +17,7 @@ const DiscordInvite: React.FC = () => {
             onHoverEnd={() => setIsHovered(false)}
         >
             <div className="flex items-center space-x-4 z-10">
-                <motion.div
+                <m.div
                     animate={{
                         y: isHovered ? -5 : 0,
                         rotate: isHovered ? -10 : 0
@@ -28,7 +28,7 @@ const DiscordInvite: React.FC = () => {
                         size={40}
                         className="text-orange-500 dark:text-orange-400"
                     />
-                </motion.div>
+                </m.div>
                 <div>
                     <h3 className="text-xl font-bold mb-1">Join Our Discord</h3>
                     <p className="text-gray-600 dark:text-gray-300 text-sm">
@@ -37,7 +37,7 @@ const DiscordInvite: React.FC = () => {
                     </p>
                 </div>
             </div>
-            <motion.div
+            <m.div
                 className="absolute right-8 top-1/2 transform -translate-y-1/2"
                 animate={{
                     x: [0, 10, 0],
@@ -54,8 +54,8 @@ const DiscordInvite: React.FC = () => {
                 <span className="text-orange-500 dark:text-orange-400 text-2xl">
                     &rarr;
                 </span>
-            </motion.div>
-            <motion.div
+            </m.div>
+            <m.div
                 className="absolute inset-0 bg-orange-100 dark:bg-orange-900 opacity-0"
                 initial={{ scale: 0, x: "100%", y: "-100%" }}
                 animate={{
@@ -66,7 +66,7 @@ const DiscordInvite: React.FC = () => {
                 }}
                 transition={{ duration: 0.5 }}
             />
-        </motion.a>
+        </m.a>
     )
 }
 

--- a/components/decoding-bitcoin/markdown-ui/exercise-selector.tsx
+++ b/components/decoding-bitcoin/markdown-ui/exercise-selector.tsx
@@ -1,7 +1,8 @@
 "use client"
 import React, { useState } from "react"
 import { Sandpack } from "@codesandbox/sandpack-react"
-import { motion, AnimatePresence } from "framer-motion"
+import * as m from "framer-motion/m"
+import { AnimatePresence } from "framer-motion"
 import { CodeIcon, PencilIcon, ArrowLeftIcon } from "lucide-react"
 import { gruvboxDark } from "@codesandbox/sandpack-themes"
 
@@ -56,7 +57,7 @@ const ExerciseSelector: React.FC<ExerciseSelectorProps> = ({
     }
 
     return (
-        <motion.div
+        <m.div
             className="max-w-5xl mx-auto py-4 full-width"
             variants={containerVariants}
             initial="hidden"
@@ -69,7 +70,7 @@ const ExerciseSelector: React.FC<ExerciseSelectorProps> = ({
                         P2PK ScriptPubKey Decoder Exercise
                     </div>
                     {selectedLanguage && (
-                        <motion.button
+                        <m.button
                             onClick={() => setSelectedLanguage(null)}
                             className="text-sm bg-vscode-button-light dark:bg-vscode-button-dark px-3 py-1 rounded-md hover:bg-orange-500 hover:text-white transition-colors duration-200 flex items-center"
                             whileHover={{ scale: 1.05 }}
@@ -77,7 +78,7 @@ const ExerciseSelector: React.FC<ExerciseSelectorProps> = ({
                         >
                             <ArrowLeftIcon className="w-4 h-4 mr-1" />
                             Change Language
-                        </motion.button>
+                        </m.button>
                     )}
                 </div>
 
@@ -85,7 +86,7 @@ const ExerciseSelector: React.FC<ExerciseSelectorProps> = ({
                 <div className="p-4">
                     <AnimatePresence mode="wait">
                         {!selectedLanguage ? (
-                            <motion.div
+                            <m.div
                                 key="language-selection"
                                 initial={{ opacity: 0 }}
                                 animate={{ opacity: 1 }}
@@ -116,7 +117,7 @@ const ExerciseSelector: React.FC<ExerciseSelectorProps> = ({
                                     />
                                 </div>
                                 <div className="absolute inset-0 z-10 flex flex-col justify-center items-center bg-[#FFFFFF66] dark:bg-[#1E1E1E66] text-black dark:text-white backdrop-blur-[1px]">
-                                    <motion.div
+                                    <m.div
                                         initial={{ opacity: 0, y: -20 }}
                                         animate={{ opacity: 1, y: 0 }}
                                         transition={{
@@ -132,11 +133,11 @@ const ExerciseSelector: React.FC<ExerciseSelectorProps> = ({
                                             Choose your preferred language to
                                             begin
                                         </p>
-                                    </motion.div>
+                                    </m.div>
                                     <div className="flex justify-center space-x-4">
                                         {["javascript", "python"].map(
                                             (lang) => (
-                                                <motion.button
+                                                <m.button
                                                     key={lang}
                                                     onClick={() =>
                                                         handleLanguageSelect(
@@ -156,14 +157,14 @@ const ExerciseSelector: React.FC<ExerciseSelectorProps> = ({
                                                     <span className="capitalize">
                                                         {lang}
                                                     </span>
-                                                </motion.button>
+                                                </m.button>
                                             )
                                         )}
                                     </div>
                                 </div>
-                            </motion.div>
+                            </m.div>
                         ) : (
-                            <motion.div
+                            <m.div
                                 key="editor"
                                 initial={{ opacity: 0, y: 20 }}
                                 animate={{ opacity: 1, y: 0 }}
@@ -206,12 +207,12 @@ const ExerciseSelector: React.FC<ExerciseSelectorProps> = ({
                                         </div>
                                     )}
                                 </div>
-                            </motion.div>
+                            </m.div>
                         )}
                     </AnimatePresence>
                 </div>
             </div>
-        </motion.div>
+        </m.div>
     )
 }
 

--- a/components/decoding-bitcoin/markdown-ui/expandable-alert.tsx
+++ b/components/decoding-bitcoin/markdown-ui/expandable-alert.tsx
@@ -9,7 +9,8 @@ import {
     CopyIcon,
     CheckIcon
 } from "lucide-react"
-import { motion, AnimatePresence } from "framer-motion"
+import * as m from "framer-motion/m"
+import { AnimatePresence } from "framer-motion"
 import clsx from "clsx"
 
 interface ExpandableAlertProps {
@@ -149,7 +150,7 @@ export default function ExpandableAlert({
                             onMouseLeave={() => setIsHovered(false)}
                             className={`flex items-center text-base font-bold mt-3 ${headerColor}`}
                         >
-                            <motion.div
+                            <m.div
                                 animate={{
                                     y: isHovered ? (isExpanded ? -3 : 3) : 0,
                                     transition: { duration: 0.2 }
@@ -166,14 +167,14 @@ export default function ExpandableAlert({
                                         className="w-5 h-5"
                                     />
                                 )}
-                            </motion.div>
+                            </m.div>
                             <span className="ml-2">
                                 {isExpanded ? "Show less" : "Show more"}
                             </span>
                         </button>
                         <AnimatePresence>
                             {isExpanded && (
-                                <motion.div
+                                <m.div
                                     initial={{ opacity: 0, height: 0 }}
                                     animate={{ opacity: 1, height: "auto" }}
                                     exit={{ opacity: 0, height: 0 }}
@@ -181,7 +182,7 @@ export default function ExpandableAlert({
                                     className="mt-3 "
                                 >
                                     {expandedContent}
-                                </motion.div>
+                                </m.div>
                             )}
                         </AnimatePresence>
                     </>

--- a/components/decoding-bitcoin/markdown-ui/hash-functions.tsx
+++ b/components/decoding-bitcoin/markdown-ui/hash-functions.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, useCallback } from "react"
 import * as bitcoin from "bitcoinjs-lib"
 import clsx from "clsx"
 import { Code, Hash, ArrowRight, Info } from "lucide-react"
-import { motion } from "framer-motion"
+import * as m from "framer-motion/m"
 
 interface HashFunction {
     id: string
@@ -172,7 +172,7 @@ const ExampleInputs = ({ examples, onSelectExample }: ExampleInputsProps) => (
         </div>
         <div className="flex flex-col gap-3">
             {examples.map((example, i) => (
-                <motion.div
+                <m.div
                     key={i}
                     className="bg-white dark:bg-vscode-input-dark p-3 rounded-lg border border-vscode-border-light dark:border-vscode-border-dark cursor-pointer hover:border-orange-500 transition-all hover:shadow-md"
                     onClick={() => onSelectExample(example.value)}
@@ -185,7 +185,7 @@ const ExampleInputs = ({ examples, onSelectExample }: ExampleInputsProps) => (
                     <p className="text-xs text-vscode-text-light dark:text-vscode-text-dark opacity-80 mt-2">
                         {example.description}
                     </p>
-                </motion.div>
+                </m.div>
             ))}
         </div>
     </div>
@@ -274,7 +274,7 @@ const useHashComputation = (input: string, selectedHash: string) => {
 const ResultDisplay = ({ result }: { result: string }) => {
     if (!result) return null
     return (
-        <motion.div
+        <m.div
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             className="p-4 bg-green-50 dark:bg-green-900/20 rounded-lg border border-green-200 dark:border-green-800 shadow-sm"
@@ -303,14 +303,14 @@ const ResultDisplay = ({ result }: { result: string }) => {
             <div className="font-mono text-sm break-all bg-white dark:bg-black/50 p-3 rounded border border-green-200 dark:border-green-800 text-vscode-text-light dark:text-vscode-text-dark">
                 {result}
             </div>
-        </motion.div>
+        </m.div>
     )
 }
 
 const ErrorDisplay = ({ error }: { error: string }) => {
     if (!error) return null
     return (
-        <motion.div
+        <m.div
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg shadow-sm"
@@ -336,7 +336,7 @@ const ErrorDisplay = ({ error }: { error: string }) => {
                     {error}
                 </div>
             </div>
-        </motion.div>
+        </m.div>
     )
 }
 
@@ -396,7 +396,7 @@ const HashFunctions = () => {
 
                 {/* Hash Function Info (Collapsible) */}
                 {showInfo && (
-                    <motion.div
+                    <m.div
                         initial={{ opacity: 0, height: 0 }}
                         animate={{ opacity: 1, height: "auto" }}
                         exit={{ opacity: 0, height: 0 }}
@@ -416,7 +416,7 @@ const HashFunctions = () => {
                                 <li key={i}>{usage}</li>
                             ))}
                         </ul>
-                    </motion.div>
+                    </m.div>
                 )}
 
                 {/* Input Section */}

--- a/components/decoding-bitcoin/markdown-ui/hex-transaction-highlighter.tsx
+++ b/components/decoding-bitcoin/markdown-ui/hex-transaction-highlighter.tsx
@@ -1,6 +1,7 @@
 "use client"
 import React, { useState, useEffect, useCallback, useRef } from "react"
-import { motion, AnimatePresence } from "framer-motion"
+import * as m from "framer-motion/m"
+import { AnimatePresence } from "framer-motion"
 
 interface Field {
     name: string
@@ -100,7 +101,7 @@ const HexTransactionHighlighter: React.FC<HexHighlighterProps> = ({
     }
 
     return (
-        <motion.div
+        <m.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5 }}
@@ -120,7 +121,7 @@ const HexTransactionHighlighter: React.FC<HexHighlighterProps> = ({
                     </div>
                 </div>
                 <div className="w-full bg-vscode-lineNumber-light dark:bg-vscode-lineNumber-dark h-2 rounded-full">
-                    <motion.div
+                    <m.div
                         className="bg-orange-500 h-2 rounded-full"
                         initial={{ width: "0%" }}
                         animate={{
@@ -139,7 +140,7 @@ const HexTransactionHighlighter: React.FC<HexHighlighterProps> = ({
             <div className="p-6 bg-vscode-background-light dark:bg-vscode-background-dark">
                 <AnimatePresence mode="wait">
                     {gameState === GameState.Explanation && (
-                        <motion.div
+                        <m.div
                             key="explanation"
                             initial={{ opacity: 0 }}
                             animate={{ opacity: 1 }}
@@ -149,18 +150,18 @@ const HexTransactionHighlighter: React.FC<HexHighlighterProps> = ({
                                 Welcome to the {title}! Your task is to identify
                                 different parts of the hex string.
                             </p>
-                            <motion.button
+                            <m.button
                                 onClick={startGame}
                                 whileHover={{ scale: 1.05 }}
                                 whileTap={{ scale: 0.95 }}
                                 className="bg-orange-500 text-white font-bold py-2 px-4 rounded hover:bg-orange-600"
                             >
                                 Start Challenge
-                            </motion.button>
-                        </motion.div>
+                            </m.button>
+                        </m.div>
                     )}
                     {gameState === GameState.Playing && (
-                        <motion.div
+                        <m.div
                             key="question"
                             initial={{ opacity: 0 }}
                             animate={{ opacity: 1 }}
@@ -173,7 +174,7 @@ const HexTransactionHighlighter: React.FC<HexHighlighterProps> = ({
                                 </span>{" "}
                                 in the hex string.
                             </p>
-                            <motion.div
+                            <m.div
                                 className="bg-vscode-input-light dark:bg-vscode-input-dark p-4 rounded-md overflow-x-auto mb-4"
                                 animate={{
                                     backgroundColor: isIncorrect
@@ -184,7 +185,7 @@ const HexTransactionHighlighter: React.FC<HexHighlighterProps> = ({
                             >
                                 <div className="hex-container font-mono text-sm">
                                     {hexString.split("").map((char, index) => (
-                                        <motion.span
+                                        <m.span
                                             key={index}
                                             initial={{ opacity: 0 }}
                                             animate={{ opacity: 1 }}
@@ -203,14 +204,14 @@ const HexTransactionHighlighter: React.FC<HexHighlighterProps> = ({
                                             onClick={() => handleClick(index)}
                                         >
                                             {char}
-                                        </motion.span>
+                                        </m.span>
                                     ))}
                                 </div>
-                            </motion.div>
-                        </motion.div>
+                            </m.div>
+                        </m.div>
                     )}
                     {gameState === GameState.ShowingResult && (
-                        <motion.div
+                        <m.div
                             key="result"
                             initial={{ opacity: 0, y: 20 }}
                             animate={{ opacity: 1, y: 0 }}
@@ -225,15 +226,15 @@ const HexTransactionHighlighter: React.FC<HexHighlighterProps> = ({
                             <p className="text-xl font-semibold text-orange-500 mb-6">
                                 Final Score: {score}/{fields.length}
                             </p>
-                            <motion.button
+                            <m.button
                                 onClick={resetGame}
                                 whileHover={{ scale: 1.05 }}
                                 whileTap={{ scale: 0.95 }}
                                 className="bg-orange-500 text-white font-bold py-2 px-4 rounded hover:bg-orange-600"
                             >
                                 Play Again
-                            </motion.button>
-                        </motion.div>
+                            </m.button>
+                        </m.div>
                     )}
                 </AnimatePresence>
             </div>
@@ -253,7 +254,7 @@ const HexTransactionHighlighter: React.FC<HexHighlighterProps> = ({
                         >
                             Hint
                         </button>
-                        <motion.button
+                        <m.button
                             onClick={nextQuestion}
                             disabled={!isAnswered}
                             whileHover={{ scale: isAnswered ? 1.05 : 1 }}
@@ -267,7 +268,7 @@ const HexTransactionHighlighter: React.FC<HexHighlighterProps> = ({
                             {currentStep < fields.length - 1
                                 ? "Next"
                                 : "Show Result"}
-                        </motion.button>
+                        </m.button>
                     </>
                 )}
             </div>
@@ -277,7 +278,7 @@ const HexTransactionHighlighter: React.FC<HexHighlighterProps> = ({
                     white-space: pre-wrap;
                 }
             `}</style>
-        </motion.div>
+        </m.div>
     )
 }
 

--- a/components/decoding-bitcoin/markdown-ui/mailing-list-signup.tsx
+++ b/components/decoding-bitcoin/markdown-ui/mailing-list-signup.tsx
@@ -1,6 +1,7 @@
 "use client"
 import React, { useState } from "react"
-import { motion, AnimatePresence } from "framer-motion"
+import * as m from "framer-motion/m"
+import { AnimatePresence } from "framer-motion"
 import { FaEnvelope, FaCheckCircle } from "react-icons/fa"
 
 const MailingListSignup: React.FC = () => {
@@ -63,7 +64,7 @@ const MailingListSignup: React.FC = () => {
             onMouseLeave={() => setIsHovered(false)}
         >
             <div className="flex items-center space-x-4 z-10 mb-5">
-                <motion.div
+                <m.div
                     animate={{
                         y: isHovered ? -5 : 0,
                         rotate: isHovered ? -10 : 0
@@ -74,7 +75,7 @@ const MailingListSignup: React.FC = () => {
                         size={32}
                         className="text-orange-500 dark:text-orange-400"
                     />
-                </motion.div>
+                </m.div>
                 <div>
                     <h3 className="text-lg font-bold">TLDR Newsletter</h3>
                     <p className="text-gray-600 dark:text-gray-300 text-sm">
@@ -107,7 +108,7 @@ const MailingListSignup: React.FC = () => {
                         className="flex-grow px-3 py-2 text-sm rounded-md sm:rounded-r-none mb-2 sm:mb-0 focus:outline-none focus:ring-2 focus:ring-orange-500 bg-white dark:bg-vscode-navigation-dark text-gray-800 dark:text-white border border-gray-300 dark:border-gray-600"
                         required
                     />
-                    <motion.button
+                    <m.button
                         type="submit"
                         className="px-4 py-2 bg-orange-500 text-white text-sm font-bold rounded-md sm:rounded-l-none focus:outline-none focus:ring-2 focus:ring-orange-500 hover:bg-orange-600 transition-colors duration-300"
                         whileHover={{ scale: 1.05 }}
@@ -115,7 +116,7 @@ const MailingListSignup: React.FC = () => {
                         disabled={loading}
                     >
                         {loading ? "Subscribing..." : "Subscribe"}
-                    </motion.button>
+                    </m.button>
                 </div>
             </form>
 
@@ -126,7 +127,7 @@ const MailingListSignup: React.FC = () => {
 
             <AnimatePresence>
                 {(mailchimpResponse || error) && (
-                    <motion.div
+                    <m.div
                         className="mt-4 text-xs sm:text-sm font-medium"
                         initial={{ opacity: 0, y: 10 }}
                         animate={{ opacity: 1, y: 0 }}
@@ -138,11 +139,11 @@ const MailingListSignup: React.FC = () => {
                             </p>
                         )}
                         {error && <p className="text-red-500">{error}</p>}
-                    </motion.div>
+                    </m.div>
                 )}
             </AnimatePresence>
 
-            <motion.div
+            <m.div
                 className="absolute inset-0 bg-orange-100 dark:bg-orange-900 opacity-0"
                 initial={{ scale: 0, x: "100%", y: "-100%" }}
                 animate={{

--- a/components/decoding-bitcoin/markdown-ui/multisig-animation.tsx
+++ b/components/decoding-bitcoin/markdown-ui/multisig-animation.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React, { useState, useEffect, useRef } from "react"
-import { motion } from "framer-motion"
+import * as m from "framer-motion/m"
 import {
     RefreshCw,
     Maximize2,
@@ -239,14 +239,14 @@ const ConnectingLine = ({
         }`}
     >
         {isAnimating && (
-            <motion.div
+            <m.div
                 className="absolute -left-2 top-0"
                 initial={{ y: -20 }}
                 animate={{ y: 148 }}
                 transition={{ duration: 1 }}
             >
                 <Key className="text-yellow-500" size={20} />
-            </motion.div>
+            </m.div>
         )}
     </div>
 )
@@ -292,7 +292,7 @@ const MultisigWallet = ({
         </p>
         <div className="flex justify-around mb-4">
             {signatures.map((signed, index) => (
-                <motion.div
+                <m.div
                     key={index}
                     initial={false}
                     style={{
@@ -316,7 +316,7 @@ const MultisigWallet = ({
                 >
                     {signed && <Key className="text-white" size={12} />}
                     {animatingKey === index && (
-                        <motion.div
+                        <m.div
                             className="w-full h-full rounded-full bg-yellow-500 flex items-center justify-center"
                             animate={{ opacity: [0, 1] }}
                             transition={{
@@ -326,9 +326,9 @@ const MultisigWallet = ({
                             }}
                         >
                             <Key className="text-white" size={12} />
-                        </motion.div>
+                        </m.div>
                     )}
-                </motion.div>
+                </m.div>
             ))}
         </div>
     </div>

--- a/components/decoding-bitcoin/markdown-ui/opcode-data-visualizer.tsx
+++ b/components/decoding-bitcoin/markdown-ui/opcode-data-visualizer.tsx
@@ -1,6 +1,6 @@
 "use client"
 import React, { useEffect, useRef, useState } from "react"
-import { motion } from "framer-motion"
+import * as m from "framer-motion/m"
 import { OpcodeSVG } from "@/public/opCodeSVG"
 
 interface OpcodeInfo {
@@ -130,7 +130,7 @@ const OpCodeInfo: React.FC<OpCodeInfoProps> = ({
     funFact
 }) => {
     return (
-        <motion.div
+        <m.div
             className="max-w-3xl mx-auto bg-vscode-container-light dark:bg-vscode-container-dark rounded-xl overflow-hidden shadow-lg border border-vscode-lineNumber-light dark:border-vscode-lineNumber-dark"
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: "auto" }}
@@ -171,6 +171,6 @@ const OpCodeInfo: React.FC<OpCodeInfoProps> = ({
                     </div>
                 )}
             </div>
-        </motion.div>
+        </m.div>
     )
 }

--- a/components/decoding-bitcoin/markdown-ui/opcode-explorer.tsx
+++ b/components/decoding-bitcoin/markdown-ui/opcode-explorer.tsx
@@ -1,15 +1,15 @@
 "use client"
 
 import { opcodeData } from "@/content/opcode-explorer"
-import { ResetIcon } from "@radix-ui/react-icons"
-import { motion } from "framer-motion"
+import * as m from "framer-motion/m"
 import {
     RewindIcon,
     PauseIcon,
     PlayIcon,
     FastForwardIcon,
     LayoutGridIcon,
-    LayoutListIcon
+    LayoutListIcon,
+    RotateCcw
 } from "lucide-react"
 import React, { useState, useRef, useEffect, useCallback } from "react"
 
@@ -208,7 +208,7 @@ const OpCodeExplorer = ({ initialView = "expanded" }: OpCodeExplorerProps) => {
 
     return (
         <div className="mx-auto py-1 full-width">
-            <motion.div
+            <m.div
                 className="bg-vscode-container-light dark:bg-vscode-container-dark rounded-lg text-vscode-text-light dark:text-vscode-text-dark font-normal shadow-md overflow-hidden"
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
@@ -220,7 +220,7 @@ const OpCodeExplorer = ({ initialView = "expanded" }: OpCodeExplorerProps) => {
                         Bitcoin OpCode Explorer
                     </div>
                     {/* Only show the view toggle button on larger screens */}
-                    <motion.button
+                    <m.button
                         onClick={() => setIsExpandedView(!isExpandedView)}
                         className="hidden sm:flex p-2 rounded-md hover:bg-vscode-hover-light dark:hover:bg-vscode-hover-dark transition-colors duration-200 items-center"
                         whileHover={{ scale: 1.05 }}
@@ -241,7 +241,7 @@ const OpCodeExplorer = ({ initialView = "expanded" }: OpCodeExplorerProps) => {
                                 </span>
                             </>
                         )}
-                    </motion.button>
+                    </m.button>
                 </div>
 
                 {/* Main content */}
@@ -257,7 +257,7 @@ const OpCodeExplorer = ({ initialView = "expanded" }: OpCodeExplorerProps) => {
                         >
                             <div className="flex">
                                 {filteredOpCodes.map((opCode) => (
-                                    <motion.button
+                                    <m.button
                                         key={opCode}
                                         whileHover={{ scale: 1.05 }}
                                         whileTap={{ scale: 0.95 }}
@@ -278,13 +278,13 @@ const OpCodeExplorer = ({ initialView = "expanded" }: OpCodeExplorerProps) => {
                                         }
                                     >
                                         {opCode}
-                                    </motion.button>
+                                    </m.button>
                                 ))}
                             </div>
                         </div>
                     </div>
 
-                    <motion.div
+                    <m.div
                         key={selectedOpCode}
                         initial={{ opacity: 0, y: 20 }}
                         animate={{ opacity: 1, y: 0 }}
@@ -322,7 +322,7 @@ const OpCodeExplorer = ({ initialView = "expanded" }: OpCodeExplorerProps) => {
                                     </object>
                                 </div>
                                 <div className="border-2 border-dashed border-vscode-lineNumber-light dark:border-vscode-lineNumber-dark p-3 rounded-lg bg-vscode-background-light dark:bg-vscode-background-dark flex items-center justify-center">
-                                    <motion.div
+                                    <m.div
                                         whileHover={{ scale: 1.1 }}
                                         whileTap={{ scale: 0.9 }}
                                     >
@@ -334,8 +334,8 @@ const OpCodeExplorer = ({ initialView = "expanded" }: OpCodeExplorerProps) => {
                                             } transition-colors duration-300`}
                                             onClick={handlePrevious}
                                         />
-                                    </motion.div>
-                                    <motion.div
+                                    </m.div>
+                                    <m.div
                                         whileHover={{ scale: 1.1 }}
                                         whileTap={{ scale: 0.9 }}
                                     >
@@ -354,17 +354,17 @@ const OpCodeExplorer = ({ initialView = "expanded" }: OpCodeExplorerProps) => {
                                                 onClick={handlePlay}
                                             />
                                         )}
-                                    </motion.div>
-                                    <motion.div
+                                    </m.div>
+                                    <m.div
                                         whileHover={{ scale: 1.1 }}
                                         whileTap={{ scale: 0.9 }}
                                     >
-                                        <ResetIcon
+                                        <RotateCcw
                                             className="h-6 w-6 mr-4 cursor-pointer text-vscode-text-light dark:text-vscode-text-dark hover:text-orange-500 transition-colors duration-300"
                                             onClick={handleReset}
                                         />
-                                    </motion.div>
-                                    <motion.div
+                                    </m.div>
+                                    <m.div
                                         whileHover={{ scale: 1.1 }}
                                         whileTap={{ scale: 0.9 }}
                                     >
@@ -376,9 +376,9 @@ const OpCodeExplorer = ({ initialView = "expanded" }: OpCodeExplorerProps) => {
                                             } transition-colors duration-300`}
                                             onClick={handleNext}
                                         />
-                                    </motion.div>
+                                    </m.div>
                                     <div className="flex-grow bg-vscode-lineNumber-light dark:bg-vscode-lineNumber-dark h-2 rounded-full">
-                                        <motion.div
+                                        <m.div
                                             className="bg-orange-500 h-2 rounded-full"
                                             initial={{ width: "0%" }}
                                             animate={{
@@ -425,7 +425,7 @@ const OpCodeExplorer = ({ initialView = "expanded" }: OpCodeExplorerProps) => {
                                             </button>
                                         </div>
                                     </div>
-                                    <motion.div
+                                    <m.div
                                         className="font-mono text-sm leading-relaxed"
                                         initial={{ opacity: 0 }}
                                         animate={{ opacity: 1 }}
@@ -436,13 +436,13 @@ const OpCodeExplorer = ({ initialView = "expanded" }: OpCodeExplorerProps) => {
                                                 ? currentOpCode.asm
                                                 : currentOpCode.hexCode}
                                         </pre>
-                                    </motion.div>
+                                    </m.div>
                                 </div>
                             </div>
                         </div>
-                    </motion.div>
+                    </m.div>
                 </div>
-            </motion.div>
+            </m.div>
         </div>
     )
 }

--- a/components/decoding-bitcoin/markdown-ui/reorg-calculator.tsx
+++ b/components/decoding-bitcoin/markdown-ui/reorg-calculator.tsx
@@ -1,6 +1,7 @@
 "use client"
 import { useState } from "react"
-import { motion, AnimatePresence } from "framer-motion"
+import * as m from "framer-motion/m"
+import { AnimatePresence } from "framer-motion"
 import {
     Percent,
     Hash,
@@ -133,13 +134,13 @@ const ReorgCalculator = () => {
     }
 
     return (
-        <motion.div
+        <m.div
             className="w-full max-w-2xl mx-auto py-1"
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5 }}
         >
-            <motion.div
+            <m.div
                 className={`rounded-lg shadow-md overflow-hidden bg-vscode-container-dark ${colors.accent} transition-colors duration-500`}
             >
                 <div className="bg-vscode-titleBar-dark p-4 flex items-center justify-between">
@@ -169,7 +170,7 @@ const ReorgCalculator = () => {
 
                 <AnimatePresence>
                     {showFormula && (
-                        <motion.div
+                        <m.div
                             initial={{ opacity: 0, height: 0 }}
                             animate={{ opacity: 1, height: "auto" }}
                             exit={{ opacity: 0, height: 0 }}
@@ -198,13 +199,13 @@ const ReorgCalculator = () => {
                                     proportion
                                 </p>
                             </div>
-                        </motion.div>
+                        </m.div>
                     )}
                 </AnimatePresence>
 
                 <AnimatePresence>
                     {showInfo && (
-                        <motion.div
+                        <m.div
                             initial={{ opacity: 0, height: 0 }}
                             animate={{ opacity: 1, height: "auto" }}
                             exit={{ opacity: 0, height: 0 }}
@@ -244,7 +245,7 @@ const ReorgCalculator = () => {
                                 which assumes average block timing to match
                                 Satoshi's original probability model.
                             </p>
-                        </motion.div>
+                        </m.div>
                     )}
                 </AnimatePresence>
 
@@ -339,7 +340,7 @@ const ReorgCalculator = () => {
                         <div
                             className={`relative h-2 ${colors.input} rounded-full mb-3`}
                         >
-                            <motion.div
+                            <m.div
                                 className={`absolute h-full rounded-full ${colors.indicator}`}
                                 initial={{ width: "0%" }}
                                 animate={{ width: `${probability * 100}%` }}
@@ -418,8 +419,8 @@ const ReorgCalculator = () => {
                         </div>
                     </div>
                 </div>
-            </motion.div>
-        </motion.div>
+            </m.div>
+        </m.div>
     )
 }
 

--- a/components/decoding-bitcoin/markdown-ui/script-visualizer/scriptVisualizer.tsx
+++ b/components/decoding-bitcoin/markdown-ui/script-visualizer/scriptVisualizer.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useRef, useState, useCallback, useMemo } from "react"
 import { PlayIcon, PauseIcon, FastForwardIcon, RewindIcon } from "lucide-react"
-import { motion } from "framer-motion"
+import * as m from "framer-motion/m"
 import {
     ScriptExecutionConfig,
     scriptExecutionConfigs
@@ -298,7 +298,7 @@ export default function ScriptStackVisualizer({
                                         ></object>
                                     </div>
                                     <div className="border border-gray-300 dark:border-vscode-input-dark p-3 rounded-lg bg-gray-100 dark:bg-vscode-background-dark flex items-center justify-center">
-                                        <motion.div
+                                        <m.div
                                             whileHover={{ scale: 1.1 }}
                                             whileTap={{ scale: 0.9 }}
                                         >
@@ -312,8 +312,8 @@ export default function ScriptStackVisualizer({
                                                     handleStepChange("prev")
                                                 }
                                             />
-                                        </motion.div>
-                                        <motion.div
+                                        </m.div>
+                                        <m.div
                                             whileHover={{ scale: 1.1 }}
                                             whileTap={{ scale: 0.9 }}
                                         >
@@ -328,8 +328,8 @@ export default function ScriptStackVisualizer({
                                                     onClick={handlePlay}
                                                 />
                                             )}
-                                        </motion.div>
-                                        <motion.div
+                                        </m.div>
+                                        <m.div
                                             whileHover={{ scale: 1.1 }}
                                             whileTap={{ scale: 0.9 }}
                                         >
@@ -344,9 +344,9 @@ export default function ScriptStackVisualizer({
                                                     handleStepChange("next")
                                                 }
                                             />
-                                        </motion.div>
+                                        </m.div>
                                         <div className="flex-grow bg-gray-300 dark:bg-vscode-input-dark h-2 rounded-full">
-                                            <motion.div
+                                            <m.div
                                                 className="bg-orange-500 h-2 rounded-full"
                                                 initial={{ width: "0%" }}
                                                 animate={{

--- a/components/decoding-bitcoin/markdown-ui/stack-simulator.tsx
+++ b/components/decoding-bitcoin/markdown-ui/stack-simulator.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from "react"
 import { ArrowDownCircle, ArrowUpCircle } from "lucide-react"
-import { motion, AnimatePresence } from "framer-motion"
+import { AnimatePresence } from "framer-motion"
+import * as m from "framer-motion/m"
 import { Opcode, opcodes, StackItem } from "@/content/opcode-explorer"
 
 interface StackSimulatorProps {
@@ -64,7 +65,7 @@ const StackSimulator = ({ showOperations }: StackSimulatorProps) => {
 
     return (
         <div className="w-full max-w-2xl mx-auto py-1">
-            <motion.div
+            <m.div
                 className="bg-vscode-container-light dark:bg-vscode-container-dark rounded-lg text-vscode-text-light dark:text-vscode-text-dark font-normal shadow-md overflow-hidden"
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
@@ -88,7 +89,7 @@ const StackSimulator = ({ showOperations }: StackSimulatorProps) => {
                             className="flex-grow px-3 py-2 border border-vscode-lineNumber-light dark:border-vscode-lineNumber-dark rounded-md bg-vscode-input-light dark:bg-vscode-input-dark text-vscode-text-light dark:text-vscode-text-dark focus:outline-none focus:ring-2 focus:ring-orange-500"
                         />
                         <div className="flex space-x-2">
-                            <motion.button
+                            <m.button
                                 onClick={push}
                                 whileHover={{ scale: 1.05 }}
                                 whileTap={{ scale: 0.95 }}
@@ -98,8 +99,8 @@ const StackSimulator = ({ showOperations }: StackSimulatorProps) => {
                                     <ArrowDownCircle className="w-5 h-5 mr-2" />
                                     <span>Push</span>
                                 </div>
-                            </motion.button>
-                            <motion.button
+                            </m.button>
+                            <m.button
                                 onClick={pop}
                                 whileHover={{ scale: 1.05 }}
                                 whileTap={{ scale: 0.95 }}
@@ -109,7 +110,7 @@ const StackSimulator = ({ showOperations }: StackSimulatorProps) => {
                                     <ArrowUpCircle className="w-5 h-5 mr-2" />
                                     <span>Pop</span>
                                 </div>
-                            </motion.button>
+                            </m.button>
                         </div>
                     </div>
 
@@ -120,7 +121,7 @@ const StackSimulator = ({ showOperations }: StackSimulatorProps) => {
                             </div>
                             <div className="flex flex-wrap gap-2">
                                 {opcodes.map((opcode) => (
-                                    <motion.button
+                                    <m.button
                                         key={opcode.name}
                                         whileHover={{ scale: 1.05 }}
                                         whileTap={{ scale: 0.95 }}
@@ -128,7 +129,7 @@ const StackSimulator = ({ showOperations }: StackSimulatorProps) => {
                                         className="px-2 py-1 bg-vscode-file-light dark:bg-vscode-file-dark text-vscode-text-light dark:text-vscode-text-dark rounded-md hover:bg-vscode-hover-light dark:hover:bg-vscode-hover-dark focus:outline-none focus:ring-2 focus:ring-vscode-hover-light dark:focus:ring-vscode-hover-dark focus:ring-opacity-50 text-sm whitespace-nowrap"
                                     >
                                         {opcode.name}
-                                    </motion.button>
+                                    </m.button>
                                 ))}
                             </div>
                         </div>
@@ -144,21 +145,21 @@ const StackSimulator = ({ showOperations }: StackSimulatorProps) => {
                         </div>
                         <AnimatePresence>
                             {stack.length === 0 ? (
-                                <motion.p
+                                <m.p
                                     initial={{ opacity: 0 }}
                                     animate={{ opacity: 1 }}
                                     exit={{ opacity: 0 }}
                                     className="text-vscode-text-light dark:text-vscode-text-dark text-center py-2"
                                 >
                                     Stack is empty
-                                </motion.p>
+                                </m.p>
                             ) : (
                                 <div className="space-y-2">
                                     {stack
                                         .slice()
                                         .reverse()
                                         .map((item, index) => (
-                                            <motion.div
+                                            <m.div
                                                 key={`${index}-${item}`}
                                                 initial={{ opacity: 0, y: -20 }}
                                                 animate={{ opacity: 1, y: 0 }}
@@ -167,7 +168,7 @@ const StackSimulator = ({ showOperations }: StackSimulatorProps) => {
                                                 className={`p-2 rounded-md ${getItemColor(item)}`}
                                             >
                                                 {formatStackItem(item)}
-                                            </motion.div>
+                                            </m.div>
                                         ))}
                                 </div>
                             )}
@@ -181,7 +182,7 @@ const StackSimulator = ({ showOperations }: StackSimulatorProps) => {
                         </div>
                     )}
                 </div>
-            </motion.div>
+            </m.div>
         </div>
     )
 }

--- a/components/decoding-bitcoin/markdown-ui/transaction-serializer/TransactionDisplay.tsx
+++ b/components/decoding-bitcoin/markdown-ui/transaction-serializer/TransactionDisplay.tsx
@@ -1,6 +1,7 @@
 "use client"
 import React, { useState, useEffect } from "react"
-import { motion, AnimatePresence } from "framer-motion"
+import * as m from "framer-motion/m"
+import { AnimatePresence } from "framer-motion"
 import { Network } from "bitcoinjs-lib"
 import TransactionDecoder, { DecodedTransaction } from "./decodeTransaction"
 
@@ -157,7 +158,7 @@ const TransactionsDisplay: React.FC<TransactionsDisplayProps> = ({
                 >
                     <AnimatePresence>
                         {displayedItems.map((item, index) => (
-                            <motion.button
+                            <m.button
                                 key={index}
                                 onClick={() =>
                                     handleDetailChange(item, index, type)
@@ -216,14 +217,14 @@ const TransactionsDisplay: React.FC<TransactionsDisplayProps> = ({
                                             {satoshisToBTC(item.value)} BTC
                                         </div>
                                     )}
-                            </motion.button>
+                            </m.button>
                         ))}
                     </AnimatePresence>
                 </div>
                 {!isExpanded && remainingCount > 0 && (
                     <div className="absolute bottom-0 left-0 right-0">
                         <div className="h-12 bg-gradient-to-t from-vscode-background-light dark:from-vscode-background-dark to-transparent"></div>
-                        <motion.button
+                        <m.button
                             onClick={() =>
                                 setExpandedSections((prev) => ({
                                     ...prev,
@@ -235,7 +236,7 @@ const TransactionsDisplay: React.FC<TransactionsDisplayProps> = ({
                             whileTap={{ scale: 0.98 }}
                         >
                             Show all {type} ({remainingCount} remaining)
-                        </motion.button>
+                        </m.button>
                     </div>
                 )}
             </div>

--- a/components/decoding-bitcoin/roadmap/InteractiveRoadmap.tsx
+++ b/components/decoding-bitcoin/roadmap/InteractiveRoadmap.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { motion } from "framer-motion"
+import * as m from "framer-motion/m"
 import TransactionCreation from "../../../src/components/TransactionCreation"
 import OpCodeExplorer from "../markdown-ui/opcode-explorer"
 
@@ -46,7 +46,7 @@ export default function InteractiveRoadmap() {
                     />
 
                     {/* Floating Bitcoin image at position 129, 442 */}
-                    <motion.img
+                    <m.img
                         src="/images/decoding-bitcoin-img.webp"
                         alt="Floating Bitcoin"
                         className="absolute pointer-events-none"
@@ -70,7 +70,7 @@ export default function InteractiveRoadmap() {
                     />
 
                     {/* Transaction roadmap image at position 1105.8, 1920.31 */}
-                    <motion.img
+                    <m.img
                         src="/images/tx-roadmap.webp"
                         alt="Transaction Roadmap"
                         className="absolute pointer-events-none"
@@ -107,7 +107,7 @@ export default function InteractiveRoadmap() {
                     />
 
                     {/* Curve Taproot image at position 500.87, 4891.53 */}
-                    <motion.img
+                    <m.img
                         src="/images/curve-taproot.webp"
                         alt="Curve Taproot"
                         className="absolute pointer-events-none"

--- a/content/landing.tsx
+++ b/content/landing.tsx
@@ -1,4 +1,4 @@
-import { BitcoinIcon } from "lucide-react"
+import { BitcoinIcon, Bitcoin, Github } from "lucide-react"
 
 import screenshotTopics from "@/public/images/hero/screenshots/topics.webp"
 import screenshotGoodFirstIssues from "@/public/images/hero/screenshots/good-first-issues.webp"
@@ -22,8 +22,7 @@ import logoBTCdemy from "@/public/images/tools/btc-demy.webp"
 import discordIcon from "@/public/images/hero/socials/discord.svg"
 import githubIcon from "@/public/images/hero/socials/github.svg"
 import xIcon from "@/public/images/hero/socials/x.svg"
-import { GitHubLogoIcon } from "@radix-ui/react-icons"
-import { Bitcoin } from "lucide-react"
+
 import {
     BoltIcon,
     ChartPieIcon,
@@ -212,7 +211,7 @@ export const values = [
         description:
             "Everything we do is open source. We want your reviews and contributions",
         href: "https://github.com/bitcoin-dev-project/bitcoin-dev-project",
-        icon: GitHubLogoIcon
+        icon: Github
     },
     {
         name: "BITCOIN TECH",

--- a/content/transaction-animation-player.tsx
+++ b/content/transaction-animation-player.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useRef, useState, useCallback } from "react"
 import { PlayIcon, PauseIcon, FastForwardIcon, RewindIcon } from "lucide-react"
-import { motion } from "framer-motion"
+import * as m from "framer-motion/m"
 
 interface SvgatorPlayer {
     ready: (callback: () => void) => void
@@ -99,7 +99,7 @@ export default function TransactionAnimationPlayer({
             {/* Control Panel */}
             <div className="border border-gray-300 dark:border-vscode-input-dark p-3 rounded-lg bg-gray-100 dark:bg-vscode-background-dark flex items-center justify-center">
                 <div className="flex items-center gap-4">
-                    <motion.div
+                    <m.div
                         whileHover={{ scale: 1.1 }}
                         whileTap={{ scale: 0.9 }}
                     >
@@ -111,14 +111,14 @@ export default function TransactionAnimationPlayer({
                             } transition-colors duration-300`}
                             onClick={() => handleStepChange("prev")}
                         />
-                    </motion.div>
+                    </m.div>
 
                     {/* Step indicator */}
                     <span className="text-sm font-medium text-vscode-text-light dark:text-vscode-text-dark min-w-[80px] text-center">
                         {currentSvgIndex + 1} of {svgPaths.length}
                     </span>
 
-                    <motion.div
+                    <m.div
                         whileHover={{ scale: 1.1 }}
                         whileTap={{ scale: 0.9 }}
                     >
@@ -130,11 +130,11 @@ export default function TransactionAnimationPlayer({
                             } transition-colors duration-300`}
                             onClick={() => handleStepChange("next")}
                         />
-                    </motion.div>
+                    </m.div>
                 </div>
 
                 <div className="flex-grow ml-4 bg-gray-300 dark:bg-vscode-input-dark h-2 rounded-full">
-                    <motion.div
+                    <m.div
                         className="bg-orange-500 h-2 rounded-full"
                         initial={{ width: "0%" }}
                         animate={{

--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,9 @@ module.exports = () => {
     return plugins.reduce((acc, next) => next(acc), {
         reactStrictMode: true,
         transpilePackages: ["@bitcoin-dev-project/bdp-ui"],
+        experimental: {
+            optimizePackageImports: ["react-icons"]
+        },
         pageExtensions: ["ts", "tsx", "js", "jsx", "md", "mdx"],
         eslint: {
             dirs: ["app", "components", "layouts", "scripts"]

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
         "@heroicons/react": "^2.1.3",
         "@mailchimp/mailchimp_marketing": "^3.0.80",
         "@next/bundle-analyzer": "14.2.3",
-        "@radix-ui/react-icons": "^1.3.0",
         "@radix-ui/react-slot": "^1.0.2",
         "@tailwindcss/forms": "^0.5.7",
         "@tailwindcss/typography": "^0.5.12",
@@ -67,7 +66,6 @@
         "remark-gfm": "^4.0.0",
         "remark-github-blockquote-alert": "^1.2.1",
         "remark-math": "^6.0.0",
-        "remixicon": "^4.2.0",
         "tailwind-merge": "^2.3.0",
         "tailwindcss-animate": "^1.0.7",
         "ts-node": "^10.9.2"

--- a/public/opCodeSVG.tsx
+++ b/public/opCodeSVG.tsx
@@ -1,4 +1,4 @@
-import { motion } from "framer-motion"
+import * as m from "framer-motion/m"
 import React from "react"
 
 interface OpcodeSVGProps extends React.ComponentPropsWithoutRef<"svg"> {
@@ -98,7 +98,7 @@ export function OpcodeSVG({ svgRef, ...props }: OpcodeSVGProps) {
                 stroke="#f1760f"
             />
 
-            <motion.rect
+            <m.rect
                 id="op_push_bytes"
                 x="106.5"
                 y="463.5"
@@ -120,7 +120,7 @@ export function OpcodeSVG({ svgRef, ...props }: OpcodeSVGProps) {
                 fill="black"
             />
 
-            <motion.rect
+            <m.rect
                 id="op_push_data_1"
                 x="248.5"
                 y="463.5"
@@ -142,7 +142,7 @@ export function OpcodeSVG({ svgRef, ...props }: OpcodeSVGProps) {
                 fill="black"
             />
 
-            <motion.rect
+            <m.rect
                 id="op_push_data_2"
                 x="415.5"
                 y="463.5"
@@ -163,7 +163,7 @@ export function OpcodeSVG({ svgRef, ...props }: OpcodeSVGProps) {
                 fill="black"
             />
 
-            <motion.rect
+            <m.rect
                 id="op_push_data_4"
                 x="648.5"
                 y="463.5"
@@ -184,7 +184,7 @@ export function OpcodeSVG({ svgRef, ...props }: OpcodeSVGProps) {
                 fill="black"
             />
 
-            <motion.line
+            <m.line
                 x1="232"
                 y1="404.5"
                 x2="89"
@@ -192,7 +192,7 @@ export function OpcodeSVG({ svgRef, ...props }: OpcodeSVGProps) {
                 stroke="#fbd28c"
                 strokeWidth="3"
             />
-            <motion.line
+            <m.line
                 x1="382"
                 y1="404.5"
                 x2="233"
@@ -200,7 +200,7 @@ export function OpcodeSVG({ svgRef, ...props }: OpcodeSVGProps) {
                 stroke="#8C8C8C"
                 strokeWidth="3"
             />
-            <motion.line
+            <m.line
                 x1="382"
                 y1="404.5"
                 x2="233"
@@ -208,7 +208,7 @@ export function OpcodeSVG({ svgRef, ...props }: OpcodeSVGProps) {
                 stroke="#f9b450"
                 strokeWidth="3"
             />
-            <motion.line
+            <m.line
                 x1="581.999"
                 y1="404.5"
                 x2="382.999"
@@ -216,7 +216,7 @@ export function OpcodeSVG({ svgRef, ...props }: OpcodeSVGProps) {
                 stroke="#8C8C8C"
                 strokeWidth="3"
             />
-            <motion.line
+            <m.line
                 x1="581.999"
                 y1="404.5"
                 x2="382.999"
@@ -224,7 +224,7 @@ export function OpcodeSVG({ svgRef, ...props }: OpcodeSVGProps) {
                 stroke="#f7931a"
                 strokeWidth="3"
             />
-            <motion.line
+            <m.line
                 x1="839"
                 y1="404.5"
                 x2="583"
@@ -232,7 +232,7 @@ export function OpcodeSVG({ svgRef, ...props }: OpcodeSVGProps) {
                 stroke="#8C8C8C"
                 strokeWidth="3"
             />
-            <motion.line
+            <m.line
                 x1="839"
                 y1="404.5"
                 x2="583"
@@ -240,7 +240,7 @@ export function OpcodeSVG({ svgRef, ...props }: OpcodeSVGProps) {
                 stroke="#f1760f"
                 strokeWidth="3"
             />
-            <motion.line
+            <m.line
                 x1="839"
                 y1="404.5"
                 x2="583"
@@ -248,7 +248,7 @@ export function OpcodeSVG({ svgRef, ...props }: OpcodeSVGProps) {
                 stroke="#8C8C8C"
                 strokeWidth="3"
             />
-            <motion.line
+            <m.line
                 x1="839"
                 y1="404.5"
                 x2="583"

--- a/public/open-source-projects/issues/rustbitcoin/index.json
+++ b/public/open-source-projects/issues/rustbitcoin/index.json
@@ -137,5 +137,15 @@
       "1.0-wanted"
     ],
     "imageUrl": "https://avatars.githubusercontent.com/u/37084147?v=4"
+  },
+  {
+    "url": "https://github.com/rust-bitcoin/rust-bitcoin/issues/6279",
+    "publishedAt": "2026-05-29T19:38:02Z",
+    "title": "Destructure all errors",
+    "labels": [
+      "good first issue",
+      "code quality"
+    ],
+    "imageUrl": "https://avatars.githubusercontent.com/u/37084147?v=4"
   }
 ]

--- a/src/components/TransactionCreation.tsx
+++ b/src/components/TransactionCreation.tsx
@@ -1,5 +1,6 @@
 "use client"
-import { motion, AnimatePresence } from "framer-motion"
+import * as m from "framer-motion/m"
+import { AnimatePresence } from "framer-motion"
 import { useState } from "react"
 
 const TransactionParts = [
@@ -188,7 +189,7 @@ export default function TransactionCreation({
             <div className="flex flex-col gap-3">
                 {/* Transaction Structure */}
                 <div className="overflow-x-auto">
-                    <motion.div
+                    <m.div
                         className="flex flex-nowrap gap-1 p-2 min-w-max"
                         initial={{ opacity: 0 }}
                         animate={{ opacity: 1 }}
@@ -440,14 +441,14 @@ export default function TransactionCreation({
                                 </div>
                             </div>
                         </div>
-                    </motion.div>
+                    </m.div>
                 </div>
 
                 {/* Two Column Layout for Details and Byte Viewer */}
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
                     {/* Enhanced Details Panel */}
                     <AnimatePresence mode="wait">
-                        <motion.div
+                        <m.div
                             key={activeSection}
                             className="bg-white dark:bg-gray-800 p-4 rounded-lg lg:order-1 shadow-sm"
                             initial={{ opacity: 0 }}
@@ -513,7 +514,7 @@ export default function TransactionCreation({
                                     </div>
                                 </div>
                             </div>
-                        </motion.div>
+                        </m.div>
                     </AnimatePresence>
 
                     {/* Enhanced Byte Viewer */}
@@ -525,7 +526,7 @@ export default function TransactionCreation({
                             {transactionFields[activeSection].example
                                 .match(/.{1,2}/g)
                                 ?.map((byte, index) => (
-                                    <motion.div
+                                    <m.div
                                         key={index}
                                         className="flex flex-col items-center"
                                         initial={{ opacity: 0 }}
@@ -538,7 +539,7 @@ export default function TransactionCreation({
                                         <div className="text-xs text-gray-500 mt-1">
                                             Byte {index + 1}
                                         </div>
-                                    </motion.div>
+                                    </m.div>
                                 ))}
                         </div>
                     </div>
@@ -577,7 +578,7 @@ function TransactionBlock({
     const byteWidth = getByteWidth(field.size)
 
     return (
-        <motion.div
+        <m.div
             className={`${byteWidth} p-2 rounded-md transition-all h-[64px] flex flex-col justify-between ${
                 !isEnabled
                     ? "opacity-30 bg-gray-100 text-gray-400 dark:bg-gray-800/30 dark:text-gray-500 cursor-not-allowed"
@@ -606,6 +607,6 @@ function TransactionBlock({
                     ))
                 )}
             </div>
-        </motion.div>
+        </m.div>
     )
 }


### PR DESCRIPTION
This PR fixes #339 by:

- Lazy loading components: Switched to `next/dynamic` so that heavy components are only downloaded when they actually render on the page.

- Optimizing `framer-motion` by replacing `motion` with the slim `m` component and adding `LazyMotion` at the layout level to defer feature loading instead of bundling everything
 
- Adding `optimizePackageImports to `next.config.js` so that Next.js only bundles the specific icons used rather than the entire icon library.

- Removing the unused`bitcoinjs-lib` import that was pulling the full crypto library into the landing page 

- Adding `@mailchimp/mailchimp_marketing` and `superagent` to `serverExternalPackages` to keep them out of the client bundle

- Completely removing `remixicon` as it is unused, and swapping out `@radix-ui/react-icons` which was only used in 2-3 instances



## Demo
<img width="1868" height="1053" alt="image" src="https://github.com/user-attachments/assets/038423e5-f3ab-4b84-9d98-638de06a0458" />

---

<img width="1614" height="893" alt="image" src="https://github.com/user-attachments/assets/8acadd31-108c-4143-a1bf-245cd3b5f5f8" />


