### PR TITLE
 load only page specific components

### DIFF
--- a/app/decoding/[...slug]/page.tsx
+++ b/app/decoding/[...slug]/page.tsx
@@ -74,6 +74,12 @@ export default async function Page({ params }: { params: { slug: string[] } }) {
 
     const Layout = layouts[(post.layout as LayoutKey) || defaultLayout]
 
+    const pageComponents = Object.fromEntries(
+        Object.entries(components).filter(([key]) =>
+            (post.usedComponents as string[]).includes(key)
+        )
+    )
+
     return (
         <div className="scroll-smooth">
             <script
@@ -88,7 +94,7 @@ export default async function Page({ params }: { params: { slug: string[] } }) {
             >
                 <MDXLayoutRenderer
                     code={post.body.code}
-                    components={components}
+                    components={pageComponents}
                     toc={post.toc}
                 />
             </Layout>

--- a/app/decoding/page.tsx
+++ b/app/decoding/page.tsx
@@ -47,6 +47,12 @@ export default async function Page() {
     const { prev, next, post, authorDetails, mainContent, jsonLd } =
         getTopicData(slug)
 
+    const pageComponents = Object.fromEntries(
+        Object.entries(components).filter(([key]) =>
+            (post.usedComponents as string[]).includes(key)
+        )
+    )
+
     return (
         <>
             <script
@@ -61,7 +67,7 @@ export default async function Page() {
             >
                 <MDXLayoutRenderer
                     code={post.body.code}
-                    components={components}
+                    components={pageComponents}
                     toc={post.toc}
                 />
             </TopicLayout>

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -42,7 +42,20 @@ const computedFields: ComputedFields = {
         type: "string",
         resolve: (doc) => doc._raw.sourceFilePath
     },
-    toc: { type: "string", resolve: (doc) => extractTocHeadings(doc.body.raw) }
+    toc: { type: "string", resolve: (doc) => extractTocHeadings(doc.body.raw) },
+    usedComponents: {
+        type: "json",
+        resolve: (doc) => {
+            const raw = doc.body.raw
+            const jsxMatches = raw.match(/<([A-Z][a-zA-Z0-9]+)/g) ?? []
+            const found = new Set(jsxMatches.map((m: string) => m.slice(1)))
+
+            if (raw.includes("![")) found.add("Image")
+            if (/\[.+?\]\(/.test(raw)) found.add("CustomLink")
+
+            return Array.from(found)
+        }
+    }
 }
 
 export const Topic = defineDocumentType(() => ({


### PR DESCRIPTION
This PR fixes #340 by:

- [x] adding a computed field that scans each MDX file's raw content at build time using regex. This runs at build time and adds zero runtime cost.
- [x] Filtering the full components map so that the MDX renderer only receives the components relevant to the current page instead of all 25+.

Pages like `technical-foundation` and `transaction_exercises` now register 0 component chunks. `transaction-signing` registers only the 4 components that are actually used, down from the 25.
 
 
### Before:

technical-foundation:
<img width="1846" height="726" alt="Screenshot from 2026-06-16 13-30-05" src="https://github.com/user-attachments/assets/b8b46820-90e8-492e-b0b6-2805aa1bdfbb" />


transaction-exercises:
<img width="1846" height="726" alt="Screenshot from 2026-06-16 13-31-15" src="https://github.com/user-attachments/assets/c8e546b1-a4d6-4c48-9d5d-41bba81f74de" />

transaction-signing:

<img width="1846" height="726" alt="Screenshot from 2026-06-16 13-30-54" src="https://github.com/user-attachments/assets/b63335a9-50d5-46ab-8d3e-82d80fe79d1e" />



### After
<img width="1846" height="726" alt="Screenshot from 2026-06-16 13-34-41" src="https://github.com/user-attachments/assets/571df490-4eed-492f-9cea-552c7914c7b0" />
