### PR TITLE
Update get funded submenu

### DIFF
--- a/app/(explore)/get-funded/page.tsx
+++ b/app/(explore)/get-funded/page.tsx
@@ -183,7 +183,7 @@ export default function Career() {
                                 </div>
 
                                 <a
-                                    href="https://adamjonas.com/"
+                                    href="https://adamjonas.com/bitcoin/funding/grants/grants-bitcoin-open-source/"
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     className="relative inline-flex h-8 items-center overflow-hidden rounded-[20px] border-2 border-[#C7C1B6] bg-[#E1DBD0] text-xs font-semibold text-black transition-all hover:scale-105"
@@ -234,7 +234,7 @@ export default function Career() {
                     </section>
 
                     <section
-                        id="organisations"
+                        id="organizations"
                         className="flex scroll-mt-24 flex-col gap-5"
                     >
                         <div className="flex flex-col gap-2">
@@ -243,7 +243,7 @@ export default function Career() {
                             </SectionHeading>
                             <p className="font-quicksand text-lg leading-[1.4] lg:text-xl">
                                 Various exchanges and individuals have sponsored
-                                devs in the past, but the below orgs have become
+                                devs in the past, but the organizations below have become
                                 the main distributors of grants over the last
                                 couple of years.
                             </p>

--- a/components/get-funded/get-funded-mega-menu.tsx
+++ b/components/get-funded/get-funded-mega-menu.tsx
@@ -17,6 +17,41 @@ const GetFundedMegaMenu = ({ isDarkMode }: { isDarkMode?: boolean }) => {
     const [open, setOpen] = useState(false)
     const close = () => setOpen(false)
 
+    const MenuColumn = ({ sections, close }: { sections: typeof NAV_SECTIONS; close: () => void }) => (
+        <div className="flex flex-col gap-y-6">
+            {sections.map((section) => (
+                <div key={section.title} className="flex flex-col gap-2.5">
+                    {section.href ? (
+                        <Link
+                            href={section.href}
+                            onClick={close}
+                            className="font-montserrat text-xs font-bold uppercase tracking-wide text-brand-dark/50 transition-colors hover:text-brand-orange-100"
+                        >
+                            {section.title}
+                        </Link>
+                    ) : (
+                        <h3 className="font-montserrat text-xs font-bold uppercase tracking-wide text-brand-dark/50">
+                            {section.title}
+                        </h3>
+                    )}
+                    <ul className="flex flex-col gap-2">
+                        {section.items.map((item) => (
+                            <li key={item.href}>
+                                <Link
+                                    href={item.href}
+                                    onClick={close}
+                                    className="font-quicksand text-sm leading-snug text-brand-dark/80 transition-colors hover:text-brand-orange-100"
+                                >
+                                    {item.label}
+                                </Link>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            ))}
+        </div>
+    )
+
     return (
         <div
             className="relative"
@@ -63,40 +98,13 @@ const GetFundedMegaMenu = ({ isDarkMode }: { isDarkMode?: boolean }) => {
                     open ? "visible opacity-100" : "invisible opacity-0"
                 )}
             >
-                <div className="grid w-[36rem] grid-cols-2 gap-x-10 gap-y-6 rounded-2xl border border-black/5 bg-[#F3EFEA] p-6 shadow-lg">
-                    {NAV_SECTIONS.map((section) => (
-                        <div
-                            key={section.title}
-                            className="flex flex-col gap-2.5"
-                        >
-                            {section.href ? (
-                                <Link
-                                    href={section.href}
-                                    onClick={close}
-                                    className="font-montserrat text-xs font-bold uppercase tracking-wide text-brand-dark/50 transition-colors hover:text-brand-orange-100"
-                                >
-                                    {section.title}
-                                </Link>
-                            ) : (
-                                <h3 className="font-montserrat text-xs font-bold uppercase tracking-wide text-brand-dark/50">
-                                    {section.title}
-                                </h3>
-                            )}
-                            <ul className="flex flex-col gap-2">
-                                {section.items.map((item) => (
-                                    <li key={item.href}>
-                                        <Link
-                                            href={item.href}
-                                            onClick={close}
-                                            className="font-quicksand text-sm leading-snug text-brand-dark/80 transition-colors hover:text-brand-orange-100"
-                                        >
-                                            {item.label}
-                                        </Link>
-                                    </li>
-                                ))}
-                            </ul>
-                        </div>
-                    ))}
+             <div className="flex w-[36rem] gap-x-10 rounded-2xl border border-black/5 bg-[#F3EFEA] p-6 shadow-lg">
+                <div className="flex flex-col gap-y-6">
+                    <MenuColumn sections={NAV_SECTIONS.filter(s => s.columnIndex === 1)} close={close} />
+                </div>
+                <div className="flex flex-col gap-y-6">
+                    <MenuColumn sections={NAV_SECTIONS.filter(s => s.columnIndex === 2)} close={close} />
+                </div>
                 </div>
             </div>
         </div>

--- a/components/sidebar-filter.tsx
+++ b/components/sidebar-filter.tsx
@@ -43,8 +43,8 @@ const SidebarFilter = ({
             args: repos
         },
         {
-            title: "Organisations",
-            placeholder: "Search Organisations",
+            title: "Organizations",
+            placeholder: "Search Organizations",
             args: orgs
         }
     ]

--- a/data/path-and-stories.tsx
+++ b/data/path-and-stories.tsx
@@ -6,7 +6,7 @@ import { Callout, ExtLink } from "@/components/get-funded/get-funded-ui"
  * hash (#) target a section on the main page; items with a slug are sub-pages.
  */
 export type NavItem = { label: string; href: string; slug?: string }
-export type NavSection = { title: string; href?: string; items: NavItem[] }
+export type NavSection = { title: string; href?: string; items: NavItem[]; columnIndex?: number}
 
 export const PATH_STORIES_BASE = "/get-funded/path-and-stories"
 
@@ -16,69 +16,43 @@ export const NAV_SECTIONS: NavSection[] = [
         href: "/get-funded",
         items: [
             {
-                label: "Why consider a BOSS development ?",
+                label: "Why consider a career in bitcoin?",
                 href: "/get-funded#why-consider"
             },
             {
-                label: "Earning a grant for full-time BOSS work",
+                label: "How grants work",
                 href: "/get-funded#earning-a-grant"
             },
             {
-                label: "Adam's article about getting funded",
+                label: "Guide for grant seekers",
                 href: "/get-funded#adam-article"
             }
-        ]
+        ],
+        columnIndex: 1
     },
     {
         title: "PATHS AND STORIES",
-        items: [
-            {
-                label: "Stickies-v - Proof over visibility",
-                href: `${PATH_STORIES_BASE}/stickies-v`,
-                slug: "stickies-v"
-            },
-            {
-                label: "Chuks - Building from community",
-                href: `${PATH_STORIES_BASE}/chuks`,
-                slug: "chuks"
-            },
-            {
-                label: "Beulah - Design to bitcoin",
-                href: `${PATH_STORIES_BASE}/beulah`,
-                slug: "beulah"
-            }
-        ]
+        href: "/get-funded#paths-and-stories",
+        items: [],
+        columnIndex: 1
     },
     {
-        title: "TIPS AND CHECKLIST",
-        items: [
-            {
-                label: "Checklist to getting funded",
-                href: "/get-funded#checklist"
-            }
-        ]
+        title: "CHECKLIST",
+        href: "/get-funded#checklist",
+        items: [],
+        columnIndex: 2
     },
     {
-        title: "ORGANISATIONS",
-        items: [
-            {
-                label: "View Organisations",
-                href: "/get-funded#organisations"
-            }
-        ]
+        title: "FUNDING ORGANIZATIONS",
+        href: "/get-funded#organizations",
+        items: [],
+        columnIndex: 2
     },
     {
         title: "APPLY",
-        items: [
-            {
-                label: "One form, multiple applications",
-                href: "/get-funded#apply"
-            },
-            {
-                label: "Common Application",
-                href: "/get-funded#common-application"
-            }
-        ]
+        href: "/get-funded#apply",
+        items: [],
+        columnIndex: 2
     }
 ]
 


### PR DESCRIPTION
Updates to the Get Funded submenu. Removed redundant items, cleaned up the wording, and explicitly assigned items to either column 1 or column 2 of the submenu.

Before:

<img width="562" height="411" alt="image" src="https://github.com/user-attachments/assets/c7cb6f00-597a-43d5-89bb-07390bfbadc4" />

After:

<img width="573" height="258" alt="image" src="https://github.com/user-attachments/assets/3dcba21d-9f6a-42bf-9704-3b93f10d6184" />

I'm welcome to other changes for this but my main concern was tidying up the number things that we had in here.

Separately, this menu is supposed to be sticky on mobile, right? It's currently not.



