### PR TITLE
Homepage: design updates

### DIFF
--- a/components/brand/Testimonial.tsx
+++ b/components/brand/Testimonial.tsx
@@ -32,7 +32,9 @@ const Testimonial: React.FC<ITestimonial> = ({
                 backgroundColor: bgColor,
                 borderColor: color,
                 maxWidth: `${65 + index * 5}%`,
-                minHeight: `${218 + index * 2}px`
+                minHeight: `${218 + index * 2}px`,
+                maxHeight: `calc(100vh - ${100 + index * 40}px - 20px)`,
+                overflowY: "auto"
             }}
         >
             <div className="relative rounded-none h-full px-2.5 pt-[30px] pb-2.5 ">

--- a/components/landing-page/explore-section.tsx
+++ b/components/landing-page/explore-section.tsx
@@ -7,9 +7,15 @@ import React from "react"
 export const ExploreSection = () => {
     return (
         <div className="bg-[#F5EFE7] pt-24">
-            <div className="max-w-7xl mx-auto px-8 py-12 sm:py-16 md:py-20 lg:py-24">
-                <h2 className="text-2xl leading-[1.75rem] font-bold text-[#2C2C2C] text-center uppercase font-montserrat">
-                    explore your path to bitcoin
+            <div className="max-w-7xl mx-auto px-8 py-12 sm:py-16 md:py-20 lg:py-24 mb-8">
+                <h1 className="text-4xl font-bold text-[#2C2C2C] text-center font-montserrat pb-16">
+                    Free Tools and Resources for Bitcoin Tech
+                </h1>
+                <h2 className="text-2xl leading-[1.75rem] text-[#2C2C2C] italic text-center font-quicksand">
+                    Bitcoin is for you, and bitcoin needs you. It takes a
+                    village to build and maintain decentralized freedom money.
+                    See how you can make it part of your developer journey
+                    today.
                 </h2>
 
                 <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6 sm:gap-8 mt-12 md:mt-16">
@@ -30,7 +36,7 @@ export const ExploreSection = () => {
                                 <h3 className="text-xl sm:text-2xl font-bold text-brand-dark uppercase font-montserrat">
                                     {path.title}
                                 </h3>
-                                <p className="text-brand-dark text-sm sm:text-base font-quicksand leading-relaxed">
+                                <p className="text-brand-dark text-sm sm:text-base font-quicksand leading-relaxed italic">
                                     {path.description}
                                 </p>
                                 <Link

--- a/components/landing-page/faq-section.tsx
+++ b/components/landing-page/faq-section.tsx
@@ -10,7 +10,7 @@ const FaqSection = () => {
         <div className="bg-[#F5EFE7] py-24 relative">
             <div className="max-w-4xl mx-auto px-5 lg:px-8">
                 <h2 className="text-2xl font-bold text-brand-dark text-center mb-12 font-montserrat">
-                    FREQUENTLY ASKED QUESTIONS
+                    Frequently Asked Questions
                 </h2>
 
                 {/* FAQ Items */}

--- a/components/landing-page/feature-products.tsx
+++ b/components/landing-page/feature-products.tsx
@@ -8,12 +8,12 @@ const FeaturedProduct = () => {
         <div className="py-12 sm:py-16 md:py-20 lg:py-24">
             <div className="max-w-7xl mx-auto px-4 sm:px-6 md:px-8 flex flex-col gap-12 sm:gap-16 lg:gap-20">
                 <div className="text-center max-w-[631px] mx-auto flex flex-col w-full gap-2 sm:gap-3">
-                    <h2 className="text-4xl sm:text-5xl font-bold text-brand-dark uppercase font-montserrat">
-                        FEATURED PRODUCTS
+                    <h2 className="text-4xl sm:text-5xl font-bold text-brand-dark font-montserrat">
+                        Featured Products
                     </h2>
-                    <p className="text-base sm:text-lg md:text-xl text-brand-dark max-w-3xl mx-auto font-quicksand px-4 sm:px-0">
-                        Explore tools crafted to support you in learning,
-                        building, and contributing to the bitcoin ecosystem.
+                    <p className="text-base sm:text-lg md:text-xl text-brand-dark max-w-3xl mx-auto font-quicksand px-4 sm:px-0 mt-6 italic">
+                        Enjoy some of our most popular resources to support you
+                        in learning, building, and contributing to bitcoin
                     </p>
                 </div>
 

--- a/components/landing-page/hero-page.tsx
+++ b/components/landing-page/hero-page.tsx
@@ -29,6 +29,7 @@ const HeroPage = ({
                     sizes="100vw"
                     priority
                 />
+                <div className="absolute inset-0 bg-black/10" />
             </div>
 
             <nav className="sticky top-0 z-50 flex items-center justify-between max-w-desktop-max mx-auto px-4 sm:px-6 lg:px-8 xl:px-12 h-20">
@@ -51,16 +52,8 @@ const HeroPage = ({
             <div className="relative pt-8 lg:pt-0 z-10 w-full px-4 lg:pl-16 max-w-desktop-max lg:mx-auto lg:px-8  pb-20">
                 <div className="flex flex-col lg:flex-row gap-8 lg:gap-0 justify-between items-start">
                     <div className="flex flex-col gap-2 lg:max-w-[568px] w-full items-center lg:pt-32 lg:items-start">
-                        <div className="inline-block">
-                            <div className="px-2.5 py-1 bg-[#6CB3DD]/44 backdrop-blur-[8px] max-w-[max-content] rounded-full border border-white border-opacity-70">
-                                <p className="text-white text-xs lg:text-sm font-medium tracking-wide font-quicksand uppercase">
-                                    ● OPEN-SOURCE LEARNING, STREAMLINED
-                                </p>
-                            </div>
-                        </div>
-
                         {/* Main Heading */}
-                        <h1 className="text-[3.5rem] lg:text-[5.25rem] text-center lg:text-left font-bold text-white leading-none font-montserrat uppercase max-w-[568px]">
+                        <h1 className="text-[3.5rem] lg:text-[5.25rem] lg:mt-16 text-center lg:text-left font-bold text-white leading-none font-montserrat uppercase max-w-[568px]">
                             BUILD THE FUTURE OF MONEY
                         </h1>
 
@@ -70,8 +63,8 @@ const HeroPage = ({
                                 {" "}
                                 Bitcoin Dev Project{" "}
                             </span>{" "}
-                            provides free and open-source tools for you to learn
-                            and contribute to bitcoin development and products
+                            is an outreach initiative for developers that want
+                            to learn and contribute to bitcoin.
                         </p>
 
                         <div className="pt-2">

--- a/components/landing-page/impact-stories.tsx
+++ b/components/landing-page/impact-stories.tsx
@@ -21,9 +21,9 @@ const ImpactStories = () => {
                         className="object-contain md:hidden"
                     />
 
-                    <div className="absolute left-1/2 -translate-x-1/2 top-[8.5%] text-center z-40">
-                        <h2 className="font-montserrat text-brand text-2xl text-nowrap font-extrabold leading-[1.2]">
-                            WORD ON THE STREET
+                    <div className="absolute left-1/2 -translate-x-1/2 md:top-[8.5%] top-[2.5%] text-center z-40">
+                        <h2 className="font-montserrat text-brand text-4xl font-bold px-4">
+                            What the Developer Community is Saying
                         </h2>
                     </div>
                 </div>

--- a/components/landing-page/newsletter.tsx
+++ b/components/landing-page/newsletter.tsx
@@ -85,7 +85,7 @@ const Newsletter = () => {
 
                             <div>
                                 <form
-                                    className="flex gap-3 max-w-xl"
+                                    className="flex flex-col sm:flex-row gap-3 max-w-xl"
                                     method="post"
                                     id="mc-embedded-subscribe-form"
                                     name="mc-embedded-subscribe-form"
@@ -101,7 +101,7 @@ const Newsletter = () => {
                                         onChange={(e) =>
                                             setEmail(e.target.value)
                                         }
-                                        className="flex-1 px-2.5 py-4 rounded-[10px] bg-brand-gray border-2 border-brand-gray-100 focus:border-brand-orange-100 focus:outline-none font-quicksand text-brand-dark placeholder:text-brand-gray-300"
+                                        className="flex-1 w-full px-2.5 py-4 rounded-[10px] bg-brand-gray border-2 border-brand-gray-100 focus:border-brand-orange-100 focus:outline-none font-quicksand text-brand-dark placeholder:text-brand-gray-300"
                                     />
                                     <button
                                         type="submit"

--- a/components/landing-page/our-mission.tsx
+++ b/components/landing-page/our-mission.tsx
@@ -24,18 +24,22 @@ const Mission = ({
 }
 const OurMission = () => {
     return (
-        <div className="bg-[#F5EFE7] py-12 sm:py-16 md:py-20 lg:py-24">
+        <div className="bg-white py-12 sm:py-16 md:py-20 lg:py-24 border-t-[20px] border-b-[20px] border-blue-300">
             <div className="max-w-7xl mx-auto px-8">
                 <div className="grid lg:grid-cols-2 gap-4 lg:gap-16 items-center">
                     <div className="flex flex-col gap-6 lg:gap-[60px] lg:max-w-[484px]">
                         <div className="flex flex-col gap-2 items-center lg:items-start">
-                            <h2 className="text-2xl leading-[1.75rem] font-bold text-[#2C2C2C]  text-center lg:text-left  font-montserrat">
-                                WHAT IS THE BITCOIN DEV PROJECT ?
+                            <h2 className="text-4xl italic font-bold text-[#2C2C2C]  text-center lg:text-left font-montserrat pb-6">
+                                The Welcome Wagon of Bitcoin Development
                             </h2>
                             <p className="text-xl text-[#2C2C2C] leading-relaxed font-quicksand text-center lg:text-left">
-                                We make tools and resources so that anyone,
-                                anywhere has the opportunity to learn and
-                                contribute to Bitcoin tech.
+                                Here at the Bitcoin Dev Project, we believe
+                                everyone should have access to quality bitcoin
+                                technical resources. It shouldn't matter who you
+                                are or where you live. From established bitcoin
+                                contributors, to aspiring ones, our commitment
+                                lies in growing and strengthening the developer
+                                ecosystem.
                             </p>
                         </div>
                         <div className="flex flex-col gap-5   ">

--- a/components/landing-page/stacked-wins.tsx
+++ b/components/landing-page/stacked-wins.tsx
@@ -7,10 +7,10 @@ const StackedWins = () => {
             <div className="max-w-7xl mx-auto px-8">
                 <div className="grid lg:grid-cols-2 gap-16 items-center">
                     <div className="text-center lg:text-left space-y-3">
-                        <h2 className="text-2xl uppercase font-bold text-brand-dark leading-tight font-montserrat">
-                            STACKED WINS
+                        <h2 className="text-2xl font-bold text-brand-dark leading-tight font-montserrat">
+                            Stacked Wins
                         </h2>
-                        <p className="text-xl text-brand-dark leading-[1.75rem] font-quicksand">
+                        <p className="text-xl text-brand-dark leading-[1.75rem] font-quicksand italic">
                             What started with a few open-source tools is now a
                             growing movement. With every contributor, every
                             event, and every resource shared, we're building

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
                 "@heroicons/react": "^2.1.3",
                 "@mailchimp/mailchimp_marketing": "^3.0.80",
                 "@next/bundle-analyzer": "14.2.3",
-                "@radix-ui/react-icons": "^1.3.0",
                 "@radix-ui/react-slot": "^1.0.2",
                 "@tailwindcss/forms": "^0.5.7",
                 "@tailwindcss/typography": "^0.5.12",
@@ -58,7 +57,6 @@
                 "remark-gfm": "^4.0.0",
                 "remark-github-blockquote-alert": "^1.2.1",
                 "remark-math": "^6.0.0",
-                "remixicon": "^4.2.0",
                 "tailwind-merge": "^2.3.0",
                 "tailwindcss-animate": "^1.0.7",
                 "ts-node": "^10.9.2"
@@ -80,7 +78,7 @@
                 "jest": "^29.7.0",
                 "jest-environment-jsdom": "^29.7.0",
                 "postcss": "^8",
-                "prettier": "^3.2.5",
+                "prettier": "^3.6.2",
                 "tailwindcss": "^3.3.0",
                 "typescript": "^5.4.5"
             }
@@ -3679,15 +3677,6 @@
                 "@types/react": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@radix-ui/react-icons": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.2.tgz",
-            "integrity": "sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==",
-            "license": "MIT",
-            "peerDependencies": {
-                "react": "^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc"
             }
         },
         "node_modules/@radix-ui/react-portal": {
@@ -15924,12 +15913,6 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
-        },
-        "node_modules/remixicon": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/remixicon/-/remixicon-4.7.0.tgz",
-            "integrity": "sha512-g2pHOofQWARWpxdbrQu5+K3C8ZbqguQFzE54HIMWFCpFa63pumaAltIgZmFMRQpKKBScRWQASQfWxS9asNCcHQ==",
-            "license": "Apache-2.0"
         },
         "node_modules/require-directory": {
             "version": "2.1.1",

--- a/utils/index.tsx
+++ b/utils/index.tsx
@@ -287,7 +287,7 @@ export const FEATUREDPRODUCTS = [
 
 export const TESTIMONIALS = [
     {
-        quote: "The variety of free, open-source material that the Bitcoin Dev Project provides is nothing short of impressive. They make exactly the kinds of tools & education that developers need.",
+        quote: "The variety of free, open-source material that the Bitcoin Dev Project provides is nothing short of impressive. They make exactly the kinds of tools and education that developers need to cut through the noise and start generating signal of their own.",
         author: "Steve Lee",
         title: "Lead, Spiral",
         logo: "/images/testimonials/spiral-orange.webp",
@@ -295,7 +295,7 @@ export const TESTIMONIALS = [
         bgColor: "#ECD4B5"
     },
     {
-        quote: "I'd highly recommend people interested in contributing to Bitcoin start their journey at BDP.",
+        quote: "I found the Bitcoin Dev Project (BDP) while doing some initial prep for the BOSS (Bitcoin Open-Source Software) program. It was a great landing page that provided an idea of which bitcoin OS projects I could think about contributing to, good first issues in those projects, and an excellent learning resource in Decoding Bitcoin which interactively teaches various concepts. In fact, adding and improving some of the material in Decoding Bitcoin is where I made my first bitcoin contributions. I'd highly recommend people interested in contributing to the bitcoin ecosystem to start their journey at BDP and see where it takes them!",
         author: "Anthony Milton",
         title: "Independent Bitcoin Researcher",
         color: "#CC7400",
@@ -303,7 +303,7 @@ export const TESTIMONIALS = [
         logo: "/images/testimonials/bitcoin-orange.webp"
     },
     {
-        quote: "The BDP is a welcoming community. It guided me to the right learning modules and tools, which helped me land a full-time job in bitcoin development!",
+        quote: "Long ago I attended a Bitcoin Core dev meetup and felt completely lost, frustrated by the lack of reliable education resources - yet I knew the bitcoin community was my home. After many years in the dark, discovering the Bitcoin Dev Project illuminated everything for me. Its welcoming community and mentorship guided my attention to focus on the right learning modules, empowering my team to place second at TabConf 2024’s Warnet workshop. Shortly after I landed a role with a Bitcoin development team and today I’m fully immersed in the technical bitcoin ecosystem.",
         author: "Matthew Vuk",
         title: "Researcher, Second",
         color: "#CC7400",
@@ -454,16 +454,18 @@ export type FAQItem = {
 export const MISSIONS = [
     {
         title: "FOCUSED ON BITCOIN",
-        description: "100% concentrated on bitcoin and related technologies"
+        description:
+            "100% concentrated on bitcoin and related freedom technologies."
     },
     {
         title: "OPEN SOURCE",
-        description: "Built in the open with your contributions."
+        description:
+            "The Bitcoin Dev Project is always free. Always open-source."
     },
     {
         title: "BITCOIN TECH",
         description:
-            "We help developers learn, practice, and build with bitcoin."
+            "We love getting deep into the weeds of the protocols, code bases, standards, and everything in between."
     }
 ]
 


### PR DESCRIPTION
I started updating copy on the homepage and ended up doing a bunch more stuff. Review of this PR is best done by looking at the homepage on the preview link. Here are some of the changes I made:

- Darkened the cloud background so there's more contrast between the white words and it's more accessible
- Removed the "open-source learning, streamlined" pill above the "BUILD THE FUTURE OF MONEY". I don't think it really communicated much and it's distracting
- Added "Free Tools and Resources for Bitcoin Tech" immediately below the fold and updated the copy under it. After reviewing some other webpages, the first thing under the fold for all of them is a short sentence on what the brand is about
- Completely reworded the "What is the Bitcoin Dev Project?" section. I think it's a waste of space to even ask the question when it can just be answered.
- Used blue bars above and below the welcome wagon section, as well as a lighter background color to visually break it up from the other sections
- Across the board I changed the headings from ALL CAPS to Title Case. While I like how punchy and bold the all caps are, and I think there are certain areas where it is appropriate, the softness of the illustrations pairs better with title case. 
- Restored the original testimonial quotes. I know this kind of messes up the scroll of the quotes, especially on mobile but these quotes are good and I don't think they should be truncated for the sake of looking nice. I think changing the testimonials to a carousel may be better, that way users aren't forced to read all of them.
- Fixed the newsletter signup on mobile. It was cut off.