### PR TITLE
fix: stop accidental submodule hash changes during build

### DIFF
--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -159,7 +159,10 @@ function createTagCount(allTopics: any[]) {
             })
         }
     })
-    writeFileSync("./app/tag-data.json", JSON.stringify(tagCount))
+    writeFileSync(
+        "./app/tag-data.json",
+        JSON.stringify(tagCount, null, 2) + "\n"
+    )
 }
 
 export default makeSource({

--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
         "compile:scripts": "rm -rf scripts && tsc --project tsconfig.scripts.json",
         "fetch-issues": "node scripts/helpers/fetch-issues.js",
         "dev": "next dev",
-        "build": "npm run submodules:update && next build && node ./rss/postbuild.mjs",
+        "build": "npm run submodules:init && next build && node ./rss/postbuild.mjs",
+        "build:deploy": "npm run submodules:update && next build && node ./rss/postbuild.mjs",
         "start": "next start",
         "lint": "next lint",
+        "submodules:init": "git submodule update --init",
         "submodules:update": "git submodule update --init --remote",
         "test": "jest"
     },

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+    "buildCommand": "npm run build:deploy",
     "redirects": [
         {
             "source": "/grants/:path*",


### PR DESCRIPTION
## Summary
This changes the default contributor build flow so `npm run build` no longer updates the Decoding Bitcoin submodule pointer. A separate deploy-specific build path still refreshes submodules when needed.

## What changed
- Split the build scripts in `package.json`
- Added `submodules:init` for contributor builds
- Kept `submodules:update` for deploy builds only
- Normalized `app/tag-data.json` generation to avoid formatting-only churn

## Why
Issue #191 describes how the previous build flow could accidentally update the `public/decoding-bitcoin` submodule hash during local builds, which created noisy unrelated diffs in contributor PRs.

This change keeps normal builds stable while preserving a deploy path that can still pull the latest submodule state.

## Validation
- `npm run build`
- `npm run build:deploy`

## Related
Closes #191