### PR TITLE
Learn: copy updates and bug fixes

### DIFF
--- a/public/learn/index.json
+++ b/public/learn/index.json
@@ -12,7 +12,7 @@
       "byBDP": "true",
       "logo": "/images/learn/BTLDR.webp",
       "title": "Bitcoin TLDR",
-      "description": "Bitcoin-dev and Lightning-dev mailing list summaries and discovery.",
+      "description": "Bitcoin-dev and lightning-dev mailing list summaries and discovery.",
       "link": "https://tldr.bitcoinsearch.xyz/"
     },
     {
@@ -115,7 +115,7 @@
       "bannerColor": "#DEE6FF",
       "logo": "/images/learn/masterbitcoin.webp",
       "title": "Mastering Bitcoin",
-      "description": "The classic Bitcoin technical resource—enhanced and expanded in its third edition.",
+      "description": "The OG bitcoin texbook. Now in its third edition.",
       "link": "https://github.com/bitcoinbook/bitcoinbook"
     },
     {
@@ -129,7 +129,7 @@
       "bannerColor": "#CEE8C0",
       "logo": "/images/learn/masterlightning.webp",
       "title": "Mastering Lightning",
-      "description": "The most comprehensive technical book on Lightning, prepare for real complexity.",
+      "description": "The most comprehensive technical book on lightning, prepare for real complexity.",
       "link": "https://github.com/lnbook/lnbook"
     },
     {
@@ -141,7 +141,7 @@
       "bannerColor": "#D1E2F3",
       "logo": "/images/learn/computer.webp",
       "title": "Tinybitcoinkeeper",
-      "description": "Playfully explore Bitcoin’s network dynamics with 150 lines of Python.",
+      "description": "Playfully explore bitcoin’s network dynamics with 150 lines of Python.",
       "link": "https://github.com/willcl-ark/tinybitcoinpeer"
     },
     {
@@ -165,7 +165,7 @@
       "bannerColor": "#FFFEDC",
       "logo": "/images/learn/transactiontutorial.webp",
       "title": "Transaction Tutorial",
-      "description": "Master SegWit, Taproot, sighashes, and timelocks with local Bitcoin scripting.",
+      "description": "Master SegWit, Taproot, sighashes, and timelocks with local bitcoin scripting.",
       "link": "https://github.com/chaincodelabs/bitcoin-tx-tutorial"
     },
     {
@@ -178,8 +178,8 @@
       ],
       "bannerColor": "#201E1E",
       "logo": "/images/learn/chaincode.webp",
-      "title": "Chaincode Lightning",
-      "description": "Curated program on Lightning development with discussions and hands-on cohort sessions.",
+      "title": "Lightning Seminar",
+      "description": "Curated discussion material and virtual cohorts on lightning development. By Chaincode Labs.",
       "link": "https://learning.chaincode.com/#seminars"
     },
     {
@@ -193,7 +193,7 @@
       "bannerColor": "#BAB6FF",
       "logo": "/images/learn/buildingonln.webp",
       "title": "Building on LN",
-      "description": "Build a Lightning graph visualizer, paid-invoice ownership game, and TypeScript.",
+      "description": "Build a lightning graph visualizer, paid-invoice ownership game, and TypeScript.",
       "link": "https://buildonln.com/"
     },
     {
@@ -219,7 +219,7 @@
       ],
       "bannerColor": "#D4D4D4",
       "logo": "/images/learn/cryptographycampbook.webp",
-      "title": "Cryptography camp workbook",
+      "title": "Cryptography Camp Workbook",
       "description": "Learn cryptographic security and proofs through a practical, hands-on workbook.",
       "link": "https://github.com/cryptography-camp/workbook"
     },
@@ -233,9 +233,9 @@
       ],
       "bannerColor": "#D5BBA4",
       "logo": "/images/learn/bitcoin-whitepaper.webp",
-      "title": "The Bitcoin Whitepaper",
-      "description": "The foundational document that introduced Bitcoin, explaining it's decentralized, P2P, electronic cash system.",
-      "link": "https://bitcoin.org/en/bitcoin-paper"
+      "title": "Bitcoin Whitepaper",
+      "description": "The 2008 paper that introduced bitcoin to the world. Written by the one and only Satoshi Nakamoto.",
+      "link": "https://bitcoindevs.xyz/bitcoin.pdf"
     },
     {
       "difficulty": "easy",
@@ -279,7 +279,7 @@
         "interactive"
       ],
       "bannerColor": "#160C12",
-      "logo": "/images/learn/bitcoin-whitepaper.webp",
+      "logo": "/images/learn/warnet.webp",
       "title": "Warnet",
       "description": "Monitor and analyze emergent behaviors of P2P networks.",
       "link": "https://warnet.dev/"


### PR DESCRIPTION
Some small fixes to the Learn page:

- Use [lowercase "bitcoin"](https://blog.casa.io/lowercase-bitcoin/) and "lightning"
- Apply title case to "Cryptography Camp Workbook"
- Update descriptions for Mastering Bitcoin, Lightning Seminar, and the whitepaper to be more informal
- Fix Warnet card image
- Point the whitepaper link to our own self hosted copy. I understand that bitcoin.org has different translations but hosting our own copy and linking to it is an embodiment of bitcoin's decentralized values.