### PR TITLE
Get Funded: add MIT DCI to list of employers

### DIFF
--- a/data/get-funded.tsx
+++ b/data/get-funded.tsx
@@ -233,6 +233,11 @@ export const WORKSPACES: ResourceLink[] = [
         name: "Localhost Research",
         detail: "San Francisco Bay Area",
         url: "https://lclhost.org/"
+    },
+    {
+        name: "MIT Digital Currency Initiative",
+        detail: "Cambridge, Massachusetts",
+        url: "https://www.dci.mit.edu/"
     }
 ]
 


### PR DESCRIPTION
This PR adds the MIT DCI to the list of places that employ bitcoin open-source developers.

https://bitcoin-dev-project-qh77comg0-btc-knowledge-base.vercel.app/get-funded

<img width="948" height="488" alt="Screenshot from 2026-08-13 11-53-55" src="https://github.com/user-attachments/assets/b7d5c742-98fa-498f-8603-06a984eaa949" />
